### PR TITLE
Handle missing  Content-Type header in response.

### DIFF
--- a/lib/src/TransFormer.dart
+++ b/lib/src/TransFormer.dart
@@ -99,7 +99,7 @@ class DefaultTransformer extends TransFormer {
     }
     var responseBody = await stream.transform(UTF8.decoder).join();
     if (options.responseType == ResponseType.JSON &&
-        response.headers.contentType.mimeType == ContentType.JSON.mimeType) {
+        response.headers.contentType?.mimeType == ContentType.JSON.mimeType) {
       return JSON.decode(responseBody);
     }
     return responseBody;


### PR DESCRIPTION
This defect was triggered by a server that replied to a request without a Content-Type header.   
The response headers (as captured by wireshark) follow:

HTTP/1.1 302 
Set-Cookie: JSESSIONID=E0DCDBB29FC3626D75D1B4876D4EBE86; Path=/derbytimer-0.1.4.BUILD-SNAPSHOT; HttpOnly
Location: /derbytimer-0.1.4.BUILD-SNAPSHOT/login;jsessionid=E0DCDBB29FC3626D75D1B4876D4EBE86?login_error=t
Content-Length: 0
Date: Sat, 30 Jun 2018 02:24:23 GMT