### PR TITLE
Add support for self-signed certificates w/ HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,23 @@ dio.cookieJar=new PersistCookieJar("./cookies");
 
 More details about [cookie_jar](https://github.com/flutterchina/cookie_jar)  see : https://github.com/flutterchina/cookie_jar .
 
+## HTTPS w/ Self-Signed Certificates
+```
+Options options = new Options(
+trustSelfSignedCerts: true,
+...
+);
+Dio dio = new Dio(options);
+
+// OR
+Dio dio = new Dio();
+dio.options.trustSelfSignedCerts = true;
+
+
+Response<String> response = await dio.get(url);
+print('response: ${response.data}');
+```
+
 ## Copyright & License
 
 This open source project authorized by https://flutterchina.club , and the license is MIT.

--- a/lib/src/Dio.dart
+++ b/lib/src/Dio.dart
@@ -281,6 +281,7 @@ class Dio {
 
   _configHttpClient(HttpClient httpClient, [bool isDefault = false]) {
     httpClient.idleTimeout = new Duration(seconds: isDefault ? 3 : 0);
+    httpClient.badCertificateCallback = (X509Certificate cert, String host, int port)=> this.options.trustSelfSignedCerts??false;
     if (onHttpClientCreate != null) {
      //user can return a new HttpClient instance
      httpClient= onHttpClientCreate(httpClient)??httpClient;

--- a/lib/src/Options.dart
+++ b/lib/src/Options.dart
@@ -31,7 +31,8 @@ class Options {
     this.headers,
     this.responseType,
     this.contentType,
-    this.validateStatus
+    this.validateStatus,
+    this.trustSelfSignedCerts
   }) {
     // set the default user-agent with Dio version
     this.headers = headers ?? {};
@@ -39,6 +40,7 @@ class Options {
     this.extra = extra ?? {};
     this.validateStatus ??=
         (int status) => status >= 200 && status < 300 || status == 304;
+    this.trustSelfSignedCerts=false;
   }
 
   /// Create a new Option from current instance with merging attributes.
@@ -53,7 +55,8 @@ class Options {
     Map<String, dynamic> headers,
     ResponseType responseType,
     ContentType contentType,
-    ValidateStatus validateStatus
+    ValidateStatus validateStatus,
+    bool trustSelfSignedCerts
   }) {
     return new Options(
       method: method??this.method,
@@ -66,7 +69,8 @@ class Options {
       headers: headers??this.headers??{},
       responseType: responseType??this.responseType,
       contentType: contentType??this.contentType,
-      validateStatus: validateStatus??this.validateStatus
+      validateStatus: validateStatus??this.validateStatus,
+      trustSelfSignedCerts: trustSelfSignedCerts??this.trustSelfSignedCerts
     );
   }
 
@@ -121,4 +125,6 @@ class Options {
   /// Custom field that you can retrieve it later in [Interceptor]、[TransFormer] and the [Response] object.
   Map<String, dynamic> extra;
 
+  //support self-signed certificates
+  bool trustSelfSignedCerts;
 }


### PR DESCRIPTION
Self-certificate errors can be bypassed by implementing:

```
Dio dio = new Dio();
dio.options.trustSelfSignedCerts = true;
```

This is accomplished by using HttpClient.badCertificateCallback()
See document here: https://api.dartlang.org/stable/1.24.3/dart-io/HttpClient/badCertificateCallback.html
```
HttpClient client = new HttpClient();
httpClient.badCertificateCallback = (X509Certificate cert, String host, int port)=> this.options.trustSelfSignedCerts??false;
```
