### PR TITLE
when wrapping response object, make sure to keep status code, etc. intact

### DIFF
--- a/lib/src/dio.dart
+++ b/lib/src/dio.dart
@@ -610,7 +610,7 @@ class Dio {
       response = new Response<T>(data: response);
     } else {
       T data = response.data;
-      response = new Response<T>(data: data);
+      response = new Response<T>(data: data, headers: response.headers, request: response.request, statusCode: response.statusCode);
     }
     return response;
   }


### PR DESCRIPTION
I want to authenticate http clients by overwriting onError interceptor, authenticating and rerunning the request. But when returning the new successful request the returned request would get transformed and lose statusCode and other information.