### PR TITLE
Fix: cancel download request didnot reutrn a CANCEL type DioError

### DIFF
--- a/lib/src/dio.dart
+++ b/lib/src/dio.dart
@@ -259,7 +259,6 @@ class Dio {
       cancelOnError: true,
     );
     return _listenCancelForAsyncTask(cancelToken, future);
-//    return future;
   }
 
   /**

--- a/lib/src/dio.dart
+++ b/lib/src/dio.dart
@@ -233,7 +233,6 @@ class Dio {
       );
     }
 
-    var streamFuture = Future.value(stream);
     stream.listen((data) {
       // Check if cancelled.
       if (cancelToken != null && cancelToken.cancelError != null) {

--- a/lib/src/dio.dart
+++ b/lib/src/dio.dart
@@ -233,6 +233,7 @@ class Dio {
       );
     }
 
+    var streamFuture = Future.value(stream);
     stream.listen((data) {
       // Check if cancelled.
       if (cancelToken != null && cancelToken.cancelError != null) {
@@ -258,7 +259,8 @@ class Dio {
       },
       cancelOnError: true,
     );
-    return future;
+    return _listenCancelForAsyncTask(cancelToken, future);
+//    return future;
   }
 
   /**

--- a/test/dio_test.dart
+++ b/test/dio_test.dart
@@ -29,7 +29,7 @@ void main() {
     test("lan", () {
      var list=[""];
      assert(list is List<String>);
-     assert(list is List<int>);
+     assert(!(list is List<int>));
     });
   });
   group('restful', () {
@@ -120,11 +120,30 @@ void main() {
 
       // The follow three requests with the same token.
       var url = "https://accounts.google.com";
-      await dio.get(url, cancelToken: token)
-          .catchError((DioError e) {
+      await dio.get(url, cancelToken: token).catchError((e) {
+        expect(CancelToken.isCancel(e), true);
         if (CancelToken.isCancel(e)) {
           expect(e.type, DioErrorType.CANCEL);
           print('$url: $e');
+        }
+      });
+    });
+
+    test("test download", () async {
+      var dio = new Dio();
+      CancelToken token = new CancelToken();
+      // In one minute, we cancel!
+      new Timer(new Duration(milliseconds: 1000), () {
+        token.cancel("cancelled");
+      });
+
+      // The follow three requests with the same token.
+      final url = 'http://download.dcloud.net.cn/HBuilder.9.0.2.macosx_64.dmg';
+      final savePath = './example/HBuilder.9.0.2.macosx_64.dmg';
+      await dio.download(url, savePath, cancelToken: token).catchError((e) {
+        expect(CancelToken.isCancel(e), true);
+        if (CancelToken.isCancel(e)) {
+          expect(e.type, DioErrorType.CANCEL);
         }
       });
     });

--- a/test/dio_test.dart
+++ b/test/dio_test.dart
@@ -113,12 +113,10 @@ void main() {
     test("test", () async {
       var dio = new Dio();
       CancelToken token = new CancelToken();
-      // In one minute, we cancel!
       new Timer(new Duration(milliseconds: 10), () {
         token.cancel("cancelled");
       });
 
-      // The follow three requests with the same token.
       var url = "https://accounts.google.com";
       await dio.get(url, cancelToken: token).catchError((e) {
         expect(CancelToken.isCancel(e), true);
@@ -132,12 +130,10 @@ void main() {
     test("test download", () async {
       var dio = new Dio();
       CancelToken token = new CancelToken();
-      // In one minute, we cancel!
       new Timer(new Duration(milliseconds: 1000), () {
         token.cancel("cancelled");
       });
 
-      // The follow three requests with the same token.
       final url = 'http://download.dcloud.net.cn/HBuilder.9.0.2.macosx_64.dmg';
       final savePath = './example/HBuilder.9.0.2.macosx_64.dmg';
       await dio.download(url, savePath, cancelToken: token).catchError((e) {


### PR DESCRIPTION
Fix cancel download request didnot reutrn a CANCEL type DioError. And add test case for cancellation of download request.looking forward your review!  @wendux @Sky24n @asmh1989 @calebisstupid @cdvv7788

Before I fix it, the test case for cancellation of download request sometimes failed with below message. And it is not always fail because the time to connect varies.
```
DioError [DioErrorType.DEFAULT]: HttpException: Connection closed while receiving data, uri = http://download.dcloud.net.cn/HBuilder.9.0.2.macosx_64.dmg

dart:async                       _Completer.completeError
package:dio/src/dio.dart 257:19  Dio.download.<fn>
===== asynchronous gap ===========================
dart:_http                       _HttpClientResponse.listen
package:dio/src/dio.dart 236:12  Dio.download
===== asynchronous gap ===========================
dart:async                       _asyncThenWrapperHelper
package:dio/src/dio.dart         Dio.download
test/dio_test.dart 137:17        main.<fn>.<fn>
```