### PR TITLE
Don't call the "onError" interceptor twice. E.g. for HTTP 404

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -286,7 +286,7 @@ dio.interceptors.add(InterceptorsWrapper(
      // 如果你想终止请求并触发一个错误,你可以返回一个`DioError`对象，或返回`dio.reject(errMsg)`，
      // 这样请求将被中止并触发异常，上层catchError会被调用。    
     },
-    onResponse:(RequestOptions  response) {
+    onResponse:(Response response) {
      // 在返回响应数据之前做一些预处理
      return response; // continue
     },

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ dio.interceptors.add(InterceptorsWrapper(
      // If you want to reject the request with a error message, 
      // you can return a `DioError` object or return `dio.reject(errMsg)`    
     },
-    onResponse:(RequestOptions  response) {
+    onResponse:(Response response) {
      // Do something with response data
      return response; // continue
     },

--- a/lib/src/cancel_token.dart
+++ b/lib/src/cancel_token.dart
@@ -37,7 +37,7 @@ class CancelToken {
     _completer.complete();
   }
 
-  _trigger(completer) {
+  _trigger(Completer completer) {
     if (completer != null) {
       completer.completeError(cancelError);
       completers.remove(completer);

--- a/lib/src/dio.dart
+++ b/lib/src/dio.dart
@@ -711,12 +711,11 @@ class Dio {
       if (statusOk) {
         future = _onResponse<T>(ret);
       } else {
-        var err = new DioError(
+        throw new DioError(
           response: ret,
           message: 'Http status error [${responseBody.statusCode}]',
           type: DioErrorType.RESPONSE,
         );
-        future = _onError<T>(err);
       }
       return await _listenCancelForAsyncTask<Response<T>>(cancelToken, future);
     } catch (e) {


### PR DESCRIPTION
The "onError" interceptor should only trigger once for a bad request.  E.g.

`() async {
	try {
		Dio dio = Dio(BaseOptions(baseUrl: 'http://www.example.com'));
		dio.interceptors.add(InterceptorsWrapper(
			onError: (DioError e) {
				print("Intercepted error");
				return e;
			}
		));
		await dio.get('/badRequest');
	} catch (e) {
		print("Caught error");
	}
}();`