### PR TITLE
Adjust case for "cookie"

### DIFF
--- a/package_src/lib/src/interceptors/cookie_mgr.dart
+++ b/package_src/lib/src/interceptors/cookie_mgr.dart
@@ -31,7 +31,7 @@ class CookieManager extends Interceptor {
     var cookies = cookieJar.loadForRequest(options.uri)
       ..addAll(options.cookies);
     String cookie = getCookies(cookies);
-    if (cookie.isNotEmpty) options.headers["cookie"] = cookie;
+    if (cookie.isNotEmpty) options.headers["Cookie"] = cookie;
   }
 
   @override


### PR DESCRIPTION
According to RFC 6265, the cookie header should be "Cookie" with a capital C.

https://tools.ietf.org/html/rfc6265#section-4.2