### PR TITLE
修复发送uint8list数据被强转string导致的数据不正确

### DIFF
--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -811,9 +811,13 @@ class Dio {
         }
       } else {
         // Call request transformer.
-        String _data = await transformer.transformRequest(options);
-        // Convert to utf8
-        bytes = utf8.encode(_data);
+        if (options.data is List<int>) {
+          bytes = options.data;
+        } else {
+          String _data = await transformer.transformRequest(options);
+          // Convert to utf8
+          bytes = utf8.encode(_data);
+        }
         // support data sending progress
         length = bytes.length;
 


### PR DESCRIPTION
建议发送数据转换前判定下是否已经是list<int>类型，避免二进制数据被强转错误