### PR TITLE
Fix example in README using BaseOptions

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -182,8 +182,8 @@ dio.options.baseUrl = "https://www.xx.com/api";
 dio.options.connectTimeout = 5000; //5s
 dio.options.receiveTimeout = 3000;
 
-// 或者通过传递一个 `options`来创建dio实例
-Options options = new BaseOptions(
+// 或者通过传递一个 `BaseOptions`来创建dio实例
+BaseOptions options = new BaseOptions(
     baseUrl: "https://www.xx.com/api",
     connectTimeout: 5000,
     receiveTimeout: 3000,

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ dio.options.baseUrl = "https://www.xx.com/api";
 dio.options.connectTimeout = 5000; //5s
 dio.options.receiveTimeout = 3000;
 
-// or new Dio with a Options instance.
-Options options = new BaseOptions(
+// or new Dio with a BaseOptions instance.
+BaseOptions options = new BaseOptions(
     baseUrl: "https://www.xx.com/api",
     connectTimeout: 5000,
     receiveTimeout: 3000,


### PR DESCRIPTION
Hey, thanks for such a great http client library.
I was so impressed by this work and I'm know fan of this.

As I follow the introduction in README, I found that `BaseOptions` usage example was not correctly assigning to the right type. (By the way IDE told me this was error)

Therefore I updated the README for the newbies.
If I was misunderstanding something just let me know.

Thanks