### PR TITLE
Make DioError catchable by implementing Exception instead of Error

### DIFF
--- a/package_src/lib/src/dio_error.dart
+++ b/package_src/lib/src/dio_error.dart
@@ -23,7 +23,7 @@ enum DioErrorType {
 }
 
 /// DioError describes the error info  when request failed.
-class DioError extends Error {
+class DioError implements Exception {
   DioError({
     this.request,
     this.response,


### PR DESCRIPTION
`dart.core.Error` is intended to be used for program failures and shouldn't be caught. `DioError extends Error` which is odd because errors like timeouts are intended to be caught. Therefore `DioError` should implement `Exception`.

From the `dart.core.Error` documentation:

```
 * Error objects thrown in the case of a program failure.
 *
 * An `Error` object represents a program failure that the programmer
 * should have avoided.
 *
 * Examples include calling a function with invalid arguments,
 * or even with the wrong number of arguments,
 * or calling it at a time when it is not allowed.
 *
 * These are not errors that a caller should expect or catch -
 * if they occur, the program is erroneous,
 * and terminating the program may be the safest response.
 *
 * Since errors are not created to be caught,
 * there is no need for subclasses to distinguish the errors.
 ```

The favourite [retry package](https://pub.dev/packages/retry) follows this rule and doesn't allow catching non-Exception classes like `DioError`.

```
// form retry source
     try {
        return await fn();
      } on Exception catch (e) { // doesn't catch DioError
```