### PR TITLE
Throw exceptions

### DIFF
--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -703,8 +703,8 @@ class Dio {
           response = _makeRequest<T>(data, cancelToken);
         } else {
           // Otherwise, use the Future value as the request result.
-          // If the return type is Error, we should throw it
-          if (data is Error) throw _assureDioError(data);
+          // If the return type is Exception, we should throw it
+          if (data is Exception) throw _assureDioError(data);
           var r = _assureResponse<T>(data);
 
           response = r;
@@ -905,7 +905,7 @@ class Dio {
     return future.then<Response<T>>((data) {
       // Strictly be a DioError instance, but we relax the restrictions
       // if (data is DioError)
-      if (data is Error) {
+      if (data is Exception) {
         return reject<T>(data);
       }
       return resolve<T>(data);
@@ -980,7 +980,7 @@ class Dio {
   DioError _assureDioError(err) {
     if (err is DioError) {
       return err;
-    } else if (err is Error) {
+    } else if (err is Exception) {
       err = new DioError(
         response: null,
         message: err.toString(),

--- a/package_src/test/exception_test.dart
+++ b/package_src/test/exception_test.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("catch DioError", () async {
+    dynamic error;
+
+    try {
+      await Dio().get("https://does.not.exist");
+      fail("did not throw");
+    } on DioError catch (e) {
+      error = e;
+    }
+
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  });
+
+  test("catch DioError as Exception", () async {
+    dynamic error;
+
+    try {
+      await Dio().get("https://does.not.exist");
+      fail("did not throw");
+    } on Exception catch (e) {
+      error = e;
+    }
+
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  });
+}


### PR DESCRIPTION
Fixes #309 

Fixes the regression introduced in #304 not throwing exceptions correctly.

I know that it is already fixed by @wendux in `2.1.5` by changing `DioError` to `DioError extends Error implements Exception`. This PR allows the removal of `extends Error` which would be dart idiomatic as explained in #304.

Sadly I can't PR the change on top of `2.1.5` because the changes haven't been pushed.

I added tests that DioErros are thrown and catchable.