### PR TITLE
Fix catch exception

### DIFF
--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -490,6 +490,13 @@ class Dio {
           if (cancelToken == null || !cancelToken.isCancelled) {
             subscription.resume();
           }
+        }).catchError((derr) async {
+          try {
+            await subscription.cancel();
+            
+          } finally {
+            completer.completeError(_assureDioError(derr));
+          }
         });
       },
       onDone: () async {


### PR DESCRIPTION
Added check for system errors when writing a file to disk. Under some circumstances, FileSystemException errors occur. For example

FileSystemException: writeFrom failed, path = '/storage/emulated/0/Download/151.pdf' (OS Error: No space left on device, errno = 28)

