### PR TITLE
Added safe query support

### DIFF
--- a/example/safe_query.dart
+++ b/example/safe_query.dart
@@ -1,0 +1,8 @@
+import 'package:dio/dio.dart';
+
+/// More examples see https://github.com/flutterchina/dio/tree/master/example
+main() async {
+  var dio = Dio();
+  Response response = await dio.get("https://google.com");
+  print(response.data);
+}

--- a/example/safe_query.dart
+++ b/example/safe_query.dart
@@ -1,8 +1,45 @@
 import 'package:dio/dio.dart';
 
-/// More examples see https://github.com/flutterchina/dio/tree/master/example
-main() async {
+void _callDefaultRequest() async {
   var dio = Dio();
-  Response response = await dio.get("https://google.com");
-  print(response.data);
+  dio.interceptors.add(LogInterceptor(request: false, responseHeader: false));
+  dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (RequestOptions options) {
+        assert(options.queryParameters.isEmpty);
+        return options;
+      }
+  ));
+  await dio.get("https://google.com");
+}
+
+void _safeQueryEnabledByDefault() async {
+  var dio = Dio();
+  dio.interceptors.add(LogInterceptor(request: false, responseHeader: false));
+  dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (RequestOptions options) {
+        assert(options.queryParameters.isEmpty);
+        return options;
+      }
+  ));
+  await dio.get("https://google.com", queryParameters: {'something': null});
+}
+
+void _safeQueryDisabled() async {
+  var dio = Dio();
+  dio.interceptors.add(LogInterceptor(request: false, responseHeader: false));
+  dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (RequestOptions options) {
+        var queryParameters = options.queryParameters;
+        assert(queryParameters.isNotEmpty);
+        assert(queryParameters['something'] == null);
+        return options;
+      }
+  ));
+  await dio.get("https://google.com", queryParameters: {'something': null}, safeQuery: false);
+}
+
+main() async {
+  _callDefaultRequest();
+  _safeQueryEnabledByDefault();
+  _safeQueryDisabled();
 }

--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -963,7 +963,7 @@ class Dio {
   RequestOptions _mergeOptions(
       Options opt, String url, data, Map<String, dynamic> queryParameters,
       bool safeQuery) {
-    if (safeQuery) {
+    if (safeQuery && queryParameters != null) {
       queryParameters.removeWhere((_, value) => value == null);
     }
     var query = (Map<String, dynamic>.from(options.queryParameters ?? {}))

--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -88,6 +88,7 @@ class Dio {
   Future<Response<T>> get<T>(
     String path, {
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
     ProgressCallback onReceiveProgress,
@@ -95,6 +96,7 @@ class Dio {
     return request<T>(
       path,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       options: _checkOptions("GET", options),
       onReceiveProgress: onReceiveProgress,
       cancelToken: cancelToken,
@@ -121,6 +123,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
     ProgressCallback onSendProgress,
@@ -131,6 +134,7 @@ class Dio {
       data: data,
       options: _checkOptions("POST", options),
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
@@ -161,6 +165,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
     ProgressCallback onSendProgress,
@@ -170,6 +175,7 @@ class Dio {
       path,
       data: data,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       options: _checkOptions("PUT", options),
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
@@ -201,6 +207,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
   }) {
@@ -208,6 +215,7 @@ class Dio {
       path,
       data: data,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       options: _checkOptions("HEAD", options),
       cancelToken: cancelToken,
     );
@@ -233,6 +241,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
   }) {
@@ -240,6 +249,7 @@ class Dio {
       path,
       data: data,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       options: _checkOptions("DELETE", options),
       cancelToken: cancelToken,
     );
@@ -265,6 +275,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     Options options,
     CancelToken cancelToken,
     ProgressCallback onSendProgress,
@@ -274,6 +285,7 @@ class Dio {
       path,
       data: data,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       options: _checkOptions("PATCH", options),
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
@@ -389,6 +401,7 @@ class Dio {
     savePath, {
     ProgressCallback onReceiveProgress,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     CancelToken cancelToken,
     lengthHeader = HttpHeaders.contentLengthHeader,
     data,
@@ -411,6 +424,7 @@ class Dio {
         data: data,
         options: options,
         queryParameters: queryParameters,
+        safeQuery: safeQuery,
         cancelToken: cancelToken ?? CancelToken(),
       );
     } on DioError catch (e) {
@@ -606,6 +620,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     CancelToken cancelToken,
     Options options,
     ProgressCallback onSendProgress,
@@ -615,6 +630,7 @@ class Dio {
       path,
       data: data,
       queryParameters: queryParameters,
+      safeQuery: safeQuery,
       cancelToken: cancelToken,
       options: options,
       onSendProgress: onSendProgress,
@@ -671,6 +687,7 @@ class Dio {
     String path, {
     data,
     Map<String, dynamic> queryParameters,
+    bool safeQuery = true,
     CancelToken cancelToken,
     Options options,
     ProgressCallback onSendProgress,
@@ -685,7 +702,7 @@ class Dio {
       onReceiveProgress = onReceiveProgress ?? options.onReceiveProgress;
     }
     RequestOptions requestOptions =
-        _mergeOptions(options, path, data, queryParameters);
+    _mergeOptions(options, path, data, queryParameters, safeQuery);
     requestOptions.onReceiveProgress = onReceiveProgress;
     requestOptions.onSendProgress = onSendProgress;
     requestOptions.cancelToken = cancelToken;
@@ -944,7 +961,11 @@ class Dio {
   }
 
   RequestOptions _mergeOptions(
-      Options opt, String url, data, Map<String, dynamic> queryParameters) {
+      Options opt, String url, data, Map<String, dynamic> queryParameters,
+      bool safeQuery) {
+    if (safeQuery) {
+      queryParameters.removeWhere((_, value) => value == null);
+    }
     var query = (Map<String, dynamic>.from(options.queryParameters ?? {}))
       ..addAll(queryParameters ?? {});
     return RequestOptions(


### PR DESCRIPTION
### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [X] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [X] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: https://github.com/flutterchina/dio/issues/361

### Pull Request Description
When I have null values in query parameters, dio put in the URL null values. Retrofit remove query null values avoiding put them in the URL.

These changes avoid Dio to put null query values in the URL. When I have `queryParameters: {'something': null}` dio creates the request: `https://endpoint?something=null`. Using safe query we avoid to put null values in the URL and the final request is: `https://endpoint` only.

There is an example in `example/safe_query.dart`.