### PR TITLE
Updated the setting of content length header to string.

### DIFF
--- a/package_src/lib/src/dio.dart
+++ b/package_src/lib/src/dio.dart
@@ -876,7 +876,7 @@ class Dio {
       options.headers[HttpHeaders.contentTypeHeader] ??=
           options.contentType.toString();
       if (length != null) {
-        options.headers[HttpHeaders.contentLengthHeader] = length;
+        options.headers[HttpHeaders.contentLengthHeader] = length?.toString();
       }
       int complete = 0;
       Stream<Uint8List>  byteStream =  stream.transform(StreamTransformer.fromHandlers(


### PR DESCRIPTION
### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [X] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [X] I have added the required tests to prove the fix/feature I am adding
- [X] I have updated the documentation (if necessary)
- [X] I have run the tests and they pass

This merge request fixes / refers to the following issues: https://github.com/flutterchina/dio/issues/391

### Pull Request Description
The option.headers expects a value type of string and was being provided an int. This caused the following error: `type 'int' is not a subtype of type 'String' of 'value'` and the following stacktrace:
```I/flutter (28968): *** DioError ***:
I/flutter (28968): DioError [DioErrorType.DEFAULT]: type 'int' is not a subtype of type 'String' of 'value'#0 __InternalLinkedHashMap&_HashVMBase&MapMixin&_LinkedHashMapMixin.[]= (dart:collection-patch/compact_hash.dart)
I/flutter (28968): #1 Dio._transformData (package:dio/src/dio.dart:879:24)
I/flutter (28968): 
I/flutter (28968): #2 Dio._makeRequest (package:dio/src/dio.dart:738:26)
I/flutter (28968): 
I/flutter (28968): #3 Dio._request.. (package:dio/src/dio.dart:711:22)
I/flutter (28968): #4 _rootRunUnary (dart:async/zone.dart:1132:38)
I/flutter (28968): #5 _CustomZone.runUnary (dart:async/zone.dart:1029:19)
I/flutter (28968): #6 _FutureListener.handleValue (dart:async/future_impl.dart:126:18)
I/flutter (28968): #7 Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:639:45)
I/flutter (28968): #8 Future._propagateToListeners (dart:async/future_impl.dart:668:32)
I/flutter (28968): #9 Future._complete (dart:async/future_impl.dart:473:7)
I/flutter (28968): #10 _SyncCompleter.complete (dart:async/future_impl.dart:51:12)
I/flutter (28968): #11 _AsyncAwaitCompleter.complete (dart:async-patch/async_patc```
