### PR TITLE
Fix no headers when using adapter

### DIFF
--- a/dio/lib/src/transformer.dart
+++ b/dio/lib/src/transformer.dart
@@ -126,6 +126,7 @@ class DefaultTransformer extends Transformer {
     if (responseBody != null &&
         responseBody.isNotEmpty &&
         options.responseType == ResponseType.json &&
+        response.headers != null &&
         _isJsonMime(response.headers[Headers.contentTypeHeader]?.first)) {
       if (jsonDecodeCallback != null) {
         return jsonDecodeCallback(responseBody);


### PR DESCRIPTION
issue #496

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

run example/adapter.dart: NoSuchMethodError: The method '[]' was called on null

### Pull Request Description

Just return responseBody when no headers in response 
...

