### PR TITLE
Add onError callback to RequestConfig to allow circumventing issue #314

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,35 @@ try {
 }
 ```
 
+Sometimes when debugging in certain IDEs, such `try`/`catch` blocks fail to actually catch thrown `DioError`s (see [flutter/flutter/issues/33427](https://github.com/flutter/flutter/issues/33427#issuecomment-523605100)). To circumvent this problem, you can pass an `onError` param to the `Options` of your request, like so:
+
+```dart
+Response _onError(DioError error) =>
+  // Silently catch errors with responses
+  // (e.g. http status errors) but preserve
+  // other errors (like SocketExceptions) in
+  // the returned Response's data parameter
+  error?.response != null
+  ? error.response
+  : Response(data: error);
+
+// ...
+
+try {
+  final response = await dio.get(
+    "https://does.not.exist/",
+    options: Options(onError: _onError)
+  );
+  if (response.data is DioError) {
+    // Re-throw the preserved DioError in a new context
+    // so our try/catch block can see it
+    throw response.data;
+  }
+} on DioError catch (e) {
+  // Handle errors
+}
+```
+
 ### DioError scheme
 
 ```dart

--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -751,7 +751,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) async {
     return _request<T>(
       path,
@@ -777,7 +777,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) {
     return request(
       uri.toString(),
@@ -798,7 +798,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) async {
     if (_closed) {
       throw DioError(error: "Dio can't establish new connection after closed.");
@@ -960,7 +960,7 @@ abstract class DioMixin implements Dio {
     } catch (e) {
       DioError err = assureDioError(e, options);
       if (options.onError != null) {
-        options.onError(err);
+        return options.onError(err);
       } else {
         throw err;
       }

--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -366,6 +366,7 @@ abstract class DioMixin implements Dio {
       options: checkOptions("GET", options),
       onReceiveProgress: onReceiveProgress,
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -381,6 +382,7 @@ abstract class DioMixin implements Dio {
       options: checkOptions("GET", options),
       onReceiveProgress: onReceiveProgress,
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -402,6 +404,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -421,6 +424,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -442,6 +446,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -461,6 +466,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -478,6 +484,7 @@ abstract class DioMixin implements Dio {
       queryParameters: queryParameters,
       options: checkOptions("HEAD", options),
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -493,6 +500,7 @@ abstract class DioMixin implements Dio {
       data: data,
       options: checkOptions("HEAD", options),
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -510,6 +518,7 @@ abstract class DioMixin implements Dio {
       queryParameters: queryParameters,
       options: checkOptions("DELETE", options),
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -525,6 +534,7 @@ abstract class DioMixin implements Dio {
       data: data,
       options: checkOptions("DELETE", options),
       cancelToken: cancelToken,
+      onError: options?.onError,
     );
   }
 
@@ -546,6 +556,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -565,6 +576,7 @@ abstract class DioMixin implements Dio {
       cancelToken: cancelToken,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: options?.onError,
     );
   }
 
@@ -739,6 +751,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
+    Function(DioError) onError,
   }) async {
     return _request<T>(
       path,
@@ -748,6 +761,7 @@ abstract class DioMixin implements Dio {
       options: options,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: onError,
     );
   }
 
@@ -763,6 +777,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
+    Function(DioError) onError,
   }) {
     return request(
       uri.toString(),
@@ -771,6 +786,7 @@ abstract class DioMixin implements Dio {
       options: options,
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
+      onError: onError,
     );
   }
 
@@ -782,6 +798,7 @@ abstract class DioMixin implements Dio {
     Options options,
     ProgressCallback onSendProgress,
     ProgressCallback onReceiveProgress,
+    Function(DioError) onError,
   }) async {
     if (_closed) {
       throw DioError(error: "Dio can't establish new connection after closed.");
@@ -793,12 +810,14 @@ abstract class DioMixin implements Dio {
       cancelToken = cancelToken ?? options.cancelToken;
       onSendProgress = onSendProgress ?? options.onSendProgress;
       onReceiveProgress = onReceiveProgress ?? options.onReceiveProgress;
+      onError = onError ?? options.onError;
     }
     RequestOptions requestOptions =
         mergeOptions(options, path, data, queryParameters);
     requestOptions.onReceiveProgress = onReceiveProgress;
     requestOptions.onSendProgress = onSendProgress;
     requestOptions.cancelToken = cancelToken;
+    requestOptions.onError = onError;
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||
             requestOptions.responseType == ResponseType.stream)) {
@@ -940,7 +959,11 @@ abstract class DioMixin implements Dio {
       }
     } catch (e) {
       DioError err = assureDioError(e, options);
-      throw err;
+      if (options.onError != null) {
+        options.onError(err);
+      } else {
+        throw err;
+      }
     }
   }
 

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -3,6 +3,7 @@ import 'package:dio/src/dio.dart';
 import 'adapter.dart';
 import 'dio_error.dart';
 import 'headers.dart';
+import 'response.dart';
 import 'transformer.dart';
 import 'cancel_token.dart';
 
@@ -69,7 +70,7 @@ class BaseOptions extends _RequestConfig {
     int maxRedirects = 5,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) : super(
           method: method,
           receiveTimeout: receiveTimeout,
@@ -106,7 +107,7 @@ class BaseOptions extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) {
     return BaseOptions(
       method: method ?? this.method,
@@ -158,7 +159,7 @@ class Options extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) : super(
           method: method,
           sendTimeout: sendTimeout,
@@ -191,7 +192,7 @@ class Options extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) {
     return Options(
       method: method ?? this.method,
@@ -236,7 +237,7 @@ class RequestOptions extends Options {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) : super(
           method: method,
           sendTimeout: sendTimeout,
@@ -277,7 +278,7 @@ class RequestOptions extends Options {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
-    Function(DioError) onError,
+    Response Function(DioError) onError,
   }) {
     return RequestOptions(
       method: method ?? this.method,
@@ -438,5 +439,5 @@ class _RequestConfig {
   /// decoder by this option, it will be used in [Transformer].
   ResponseDecoder responseDecoder;
 
-  Function(DioError) onError;
+  Response Function(DioError) onError;
 }

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -1,4 +1,7 @@
+import 'package:dio/src/dio.dart';
+
 import 'adapter.dart';
+import 'dio_error.dart';
 import 'headers.dart';
 import 'transformer.dart';
 import 'cancel_token.dart';
@@ -66,6 +69,7 @@ class BaseOptions extends _RequestConfig {
     int maxRedirects = 5,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) : super(
           method: method,
           receiveTimeout: receiveTimeout,
@@ -80,6 +84,7 @@ class BaseOptions extends _RequestConfig {
           maxRedirects: maxRedirects,
           requestEncoder: requestEncoder,
           responseDecoder: responseDecoder,
+          onError: onError,
         );
 
   /// Create a Option from current instance with merging attributes.
@@ -101,6 +106,7 @@ class BaseOptions extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) {
     return BaseOptions(
       method: method ?? this.method,
@@ -120,6 +126,7 @@ class BaseOptions extends _RequestConfig {
       maxRedirects: maxRedirects ?? this.maxRedirects,
       requestEncoder: requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
+      onError: onError ?? this.onError,
     );
   }
 
@@ -151,6 +158,7 @@ class Options extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) : super(
           method: method,
           sendTimeout: sendTimeout,
@@ -165,6 +173,7 @@ class Options extends _RequestConfig {
           maxRedirects: maxRedirects,
           requestEncoder: requestEncoder,
           responseDecoder: responseDecoder,
+          onError: onError
         );
 
   /// Create a Option from current instance with merging attributes.
@@ -182,6 +191,7 @@ class Options extends _RequestConfig {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) {
     return Options(
       method: method ?? this.method,
@@ -198,6 +208,7 @@ class Options extends _RequestConfig {
       maxRedirects: maxRedirects ?? this.maxRedirects,
       requestEncoder: requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
+      onError: onError ?? this.onError
     );
   }
 }
@@ -225,6 +236,7 @@ class RequestOptions extends Options {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) : super(
           method: method,
           sendTimeout: sendTimeout,
@@ -239,6 +251,7 @@ class RequestOptions extends Options {
           maxRedirects: maxRedirects,
           requestEncoder: requestEncoder,
           responseDecoder: responseDecoder,
+          onError: onError,
         );
 
   /// Create a Option from current instance with merging attributes.
@@ -264,6 +277,7 @@ class RequestOptions extends Options {
     int maxRedirects,
     RequestEncoder requestEncoder,
     ResponseDecoder responseDecoder,
+    Function(DioError) onError,
   }) {
     return RequestOptions(
       method: method ?? this.method,
@@ -287,6 +301,7 @@ class RequestOptions extends Options {
       maxRedirects: maxRedirects ?? this.maxRedirects,
       requestEncoder: requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
+      onError: onError ?? this.onError,
     );
   }
 
@@ -344,6 +359,7 @@ class _RequestConfig {
     this.maxRedirects = 5,
     this.requestEncoder,
     this.responseDecoder,
+    this.onError,
   }) {
     this.headers = headers ?? {};
     this.extra = extra ?? {};
@@ -421,4 +437,6 @@ class _RequestConfig {
   /// The default response decoder is utf8decoder, you can set custom
   /// decoder by this option, it will be used in [Transformer].
   ResponseDecoder responseDecoder;
+
+  Function(DioError) onError;
 }

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -51,13 +51,13 @@ void main() {
     dynamic error;
 
     final options = Options(onError: (DioError error) {
-      throw error;
+      return Response(data: error);
     });
 
     try {
-      await Dio().get("https://does.not.exist", options: options);
-      fail("did not rethrow");
-    } on Exception catch (e) {
+      final response = await Dio().get("https://does.not.exist", options: options);
+      if (response.data is DioError) throw response.data;
+    } on DioError catch (e) {
       error = e;
     }
     expect(error, isNotNull);

--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -29,4 +29,38 @@ void main() {
     expect(error, isNotNull);
     expect(error is Exception, isTrue);
   });
+
+  test("catch DioError with onError callback", () async {
+    dynamic error;
+
+    final options = Options(onError: (DioError _error) {
+      error = _error;
+      print(error);
+    });
+
+    try {
+      await Dio().get("https://does.not.exist", options: options);
+      expect(error, isNotNull);
+      expect(error is DioError, isTrue);
+    } on Exception catch (e) {
+      fail("was not caught: $e");
+    }
+  });
+
+  test('rethrow DioError from onError callback', () async {
+    dynamic error;
+
+    final options = Options(onError: (DioError error) {
+      throw error;
+    });
+
+    try {
+      await Dio().get("https://does.not.exist", options: options);
+      fail("did not rethrow");
+    } on Exception catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error is DioError, isTrue);
+  });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #314 

### Pull Request Description

Sometimes when debugging in certain IDEs, `try`/`catch` blocks fail to actually catch thrown `DioError`s (see flutter/flutter#33427, in particular [feinstein's comment](https://github.com/flutter/flutter/issues/33427#issuecomment-523605100)). To circumvent this problem, with this PR you can pass an `onError` param to the `Options` of your request, like so:

```dart
Response _onError(DioError error) =>
  // Silently catch errors with responses
  // (e.g. http status errors) but preserve
  // other errors (like SocketExceptions) in
  // the returned Response's data parameter
  error?.response != null
  ? error.response
  : Response(data: error);

// ...

try {
  final response = await dio.get(
    "https://does.not.exist/",
    options: Options(onError: _onError)
  );
  if (response.data is DioError) {
    // Re-throw the preserved DioError in a new context
    // so our try/catch block can see it
    throw response.data;
  }
} on DioError catch (e) {
  // Handle errors
}
```
