### PR TITLE
Added function to check if the current dio instance is locked

### DIFF
--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -198,6 +198,9 @@ abstract class Dio {
   /// Dio instance dequeue the request task。
   void unlock();
 
+  /// Whether Dio instance is currently locked.
+  bool locked();
+
   ///Clear the current Dio instance waiting queue.
 
   void clear();
@@ -627,6 +630,13 @@ abstract class DioMixin implements Dio {
   @override
   void unlock() {
     interceptors.requestLock.unlock();
+  }
+
+  /// Whether Dio instance is currently locked.
+
+  @override
+  bool locked() {
+    return interceptors.requestLock.locked;
   }
 
   ///Clear the current Dio instance waiting queue.


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

I just added a function to check if the current dio instance is locked it is similar to `lock` and `unlock` but to check if Dio instance is locked or not.
...

