### PR TITLE
Fixing download method failing when the directory doesn't exist yet.

### DIFF
--- a/dio/lib/src/entry/dio_for_native.dart
+++ b/dio/lib/src/entry/dio_for_native.dart
@@ -114,6 +114,9 @@ class DioForNative with DioMixin implements Dio {
       file = File(savePath.toString());
     }
 
+    //If directory (or file) doesn't exist yet, the entire method fails
+    file.createSync(recursive: true);
+
     // Shouldn't call file.writeAsBytesSync(list, flush: flush),
     // because it can write all bytes by once. Consider that the
     // file with a very big size(up 1G), it will be expensive in memory.


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This pull request fixes a problem on the native environment, where the file being downloaded cannot be saved if the path doesn't exist yet.

This error can be seem mostly on desktop environments, like Windows.

I think this closes those issues:
https://github.com/flutterchina/dio/issues/643
https://github.com/flutterchina/dio/issues/609