### PR TITLE
Make Options use a const constructor

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -137,7 +137,7 @@ class BaseOptions extends _RequestConfig {
 
 /// Every request can pass an [Options] object which will be merged with [Dio.options]
 class Options extends _RequestConfig {
-  Options({
+  const Options({
     String method,
     int sendTimeout,
     int receiveTimeout,


### PR DESCRIPTION
Making `Options` use a const constructor allows us to put options in other constructors, which is particularly nice when building APIs with a code generation tool such as `retrofit`

```dart
  /// Test authentication token and get private user information
  @POST("/v1/auth/authenticate")
  Future<AuthenticateResponse> authenticate({
    @DioOptions() Options options = const Options(sendTimeout: 1),
  });
```

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

