### PR TITLE
Fixes the HTTP2 Adapter for Requests with Payload

### DIFF
--- a/plugins/http2_adapter/test/http2_test.dart
+++ b/plugins/http2_adapter/test/http2_test.dart
@@ -23,4 +23,15 @@ void main() {
     );
     assert(response.statusCode == 404);
   });
+
+  test("request with payload", () async {
+    final dio = Dio()
+      ..options.baseUrl = "https://postman-echo.com/"
+      ..httpClientAdapter = Http2Adapter(ConnectionManager(
+        idleTimeout: 10,
+      ));
+
+    final res = await dio.post("post", data: "TEST");
+    assert(res.data["data"] == "TEST");
+  });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: 

The current HTTP2 adapter doesn't work when the request contains a payload, because it only starts sending the payload after the response header from the server has been received. However, the server won't start sending the response header until the entire payload is received from the client. Hence the connection is in a deadlock until either the client or the server times out.

This pull request fixes this issue by transmitting the entire payload body before starting to listen for responses.

...

