### PR TITLE
use endStream: true behavior when making an HTTP/2 request

### DIFF
--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -54,7 +54,7 @@ class Http2Adapter extends HttpClientAdapter {
     // Creates a new outgoing stream.
     var stream = transport.makeRequest(
       headers,
-      endStream: false,
+      endStream: true,
     );
     var _ = cancelFuture?.whenComplete(() {
       Future.delayed(Duration(seconds: 0)).then((e) {


### PR DESCRIPTION
Fix to #762 

