### PR TITLE
do not treat 304 as good status code by default

### DIFF
--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -1091,7 +1091,7 @@ abstract class DioMixin implements Dio {
       validateStatus: opt.validateStatus ??
           options.validateStatus ??
           (int status) {
-            return status >= 200 && status < 300 || status == 304;
+            return status >= 200 && status < 300;
           },
       receiveDataWhenStatusError: opt.receiveDataWhenStatusError ??
           options.receiveDataWhenStatusError ??


### PR DESCRIPTION
HTTP servers MUST NOT include any content when sending a 304. When treating
304 as success, the response body is empty and transforming the response
leads to an empty string. This then fails in `assureResponse` when
`response.data` is assigned to the variable of type `T` (which is usually
not String, but the expected body type like `List<dynamic>`) with an
exception: type 'String' is not a subtype of type 'List<dynamic>'

By treating 304 as a failure, the request throws a DioError that can
easily be checked for the statusCode and then the application can handle
the 304 however it wants to (usually by reusing the data from the cache).

I did not add a test or updated the documentation, since I wanted to get feedback on this first. I know that I could supply a custom `validateStatus` callback to reject 304 manually, but I don't see why this shouldn't be the default, since Dio always fails to convert the response if the server responds with a 304.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

