### PR TITLE
fixed version reference

### DIFF
--- a/plugins/cookie_manager/README.md
+++ b/plugins/cookie_manager/README.md
@@ -8,7 +8,7 @@ A  cookie manager for [Dio](https://github.com/flutterchina/dio).
 
 ```yaml
 dependencies:
-  dio_cookie_manager: 1.0.x  #latest version
+  dio_cookie_manager: ^1.0.0  #latest version
 ```
 
 ### Usage


### PR DESCRIPTION
if you use `1.0.x`
you are getting an exception running flutter 
```
rror on line 46, column 23 of pubspec.yaml: Invalid version constraint: Could not parse version "1.0.x". Unknown text at "1.0.x".
   ╷
46 │   dio_cookie_manager: 1.0.x
   │                       ^^^^^
   ╵
pub get failed (65;    ╵)
```

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ x] I have added the required tests to prove the fix/feature I am adding
- [ x] I have updated the documentation (if necessary)
- [ x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

