### PR TITLE
fixed documentaiton

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -375,7 +375,7 @@ class _RequestConfig {
   /// [0] meanings no timeout limit.
   int receiveTimeout;
 
-  /// The request Content-Type. The default value is [ContentType.json].
+  /// The request Content-Type. The default value is [ContentType.json.mimeType].
   /// If you want to encode request body with 'application/x-www-form-urlencoded',
   /// you can set `ContentType.parse('application/x-www-form-urlencoded')`, and [Dio]
   /// will automatically encode the request body.


### PR DESCRIPTION
ContentType.json is of type ContentType
to get application/x-www-form-urlencoded you need ContentType.json.mimeType

### New Pull Request Checklist

- [x ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ x] I have added the required tests to prove the fix/feature I am adding
- [ x] I have updated the documentation (if necessary)
- [ x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

