### PR TITLE
fix http 30x user-agent not working

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -119,6 +119,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       return _httpClient..connectionTimeout = _connectionTimeout;
     } else if (_defaultHttpClient == null) {
       _defaultHttpClient = HttpClient();
+      _defaultHttpClient.userAgent = null;
       _defaultHttpClient.idleTimeout = Duration(seconds: 3);
       if (onHttpClientCreate != null) {
         //user can return a HttpClient instance


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Fix that when the request is 301, 302 jumped, the link userAgent setting error after the jump
