### PR TITLE
clear connect futures in case of SocketException

### DIFF
--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -41,7 +41,14 @@ class _ConnectionManager implements ConnectionManager {
       if (_initFuture == null) {
         _connectFutures[domain] = _initFuture = _connect(options);
       }
-      transportState = await _initFuture;
+
+      try {
+        transportState = await _initFuture;
+      } on SocketException catch (_) {
+        _connectFutures.remove(domain);
+        rethrow;
+      }
+
       if (_forceClosed) {
         transportState.dispose();
       } else {


### PR DESCRIPTION
Currently in case if `await SecureSocket.connect` throws `SocketException` it's cached in `_connectFutures` and all the following `getConnection` requests fail with the same exception.
<br>
Steps to reproduce:

- Turn off network
- Open the app and make an API call. It will return `SocketException: Failed host lookup: 'myapi.com' (OS Error: No address associated with hostname, errno = 7)`
- Turn on network
- Make another API call. It will return the same `SocketException: Failed host lookup: 'myapi.com' (OS Error: No address associated with hostname, errno = 7)`
