### PR TITLE
make headers case insensitive

### DIFF
--- a/dio/lib/src/headers.dart
+++ b/dio/lib/src/headers.dart
@@ -1,5 +1,7 @@
 import 'package:http_parser/http_parser.dart';
 
+import 'utils.dart';
+
 typedef HeaderForEachCallback = void Function(String name, List<String> values);
 
 class Headers {
@@ -20,10 +22,12 @@ class Headers {
 
   Map<String, List<String>> get map => _map;
 
-  Headers() : _map = <String, List<String>>{};
+  Headers() : _map = caseInsensitiveKeyMap<List<String>>();
 
   Headers.fromMap(Map<String, List<String>> map)
-      : _map = map.map((k, v) => MapEntry(k.trim().toLowerCase(), v));
+      : _map = caseInsensitiveKeyMap<List<String>>(
+          value: map.map((k, v) => MapEntry(k.trim().toLowerCase(), v)),
+        );
 
   /// Returns the list of values for the header named [name]. If there
   /// is no header with the provided name, [:null:] will be returned.

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -2,6 +2,7 @@ import 'adapter.dart';
 import 'headers.dart';
 import 'transformer.dart';
 import 'cancel_token.dart';
+import 'utils.dart';
 
 /// Callback to listen the progress for sending/receiving data.
 ///
@@ -137,7 +138,7 @@ class BaseOptions extends _RequestConfig {
 
 /// Every request can pass an [Options] object which will be merged with [Dio.options]
 class Options extends _RequestConfig {
- Options({
+  Options({
     String method,
     int sendTimeout,
     int receiveTimeout,
@@ -347,7 +348,7 @@ class _RequestConfig {
     this.requestEncoder,
     this.responseDecoder,
   }) {
-    this.headers = headers ?? {};
+    this.headers = caseInsensitiveKeyMap(value: headers);
     this.extra = extra ?? {};
     this.contentType = contentType;
   }

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'dart:convert';
 
@@ -66,4 +67,13 @@ String encodeMap(data, DioEncodeHandler handler, {bool encode = true}) {
 
   urlEncode(data, '');
   return urlData.toString();
+}
+
+Map<String, V> caseInsensitiveKeyMap<V>({Map<String, V> value}) {
+  final map = LinkedHashMap<String, V>(
+    equals: (key1, key2) => key1.toLowerCase() == key2.toLowerCase(),
+    hashCode: (key) => key.toLowerCase().hashCode,
+  );
+  if (value != null && value.isNotEmpty) map.addAll(value);
+  return map;
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues:
TarekkMA/gql_dio_link#4

### Pull Request Description
The current implementation of the headers do allow multiple header with different letter case.

for example the following header are considered as unique.
Content-type: xxxxxx
content-type: xxxxxx
CoNtEnT-TyPe: xxxxx

The current solution I have used is the same used in http package
https://github.com/dart-lang/http/blob/master/lib/src/base_request.dart#L89
...

