### PR TITLE
#844 Throw CONNECT_TIMEOUT on wifi with no internet

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -44,8 +44,13 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
     HttpClientRequest request;
     try {
-      request = await requestFuture
-          .timeout(Duration(milliseconds: options.connectTimeout));
+      if (options.connectTimeout > 0) {
+        request = await requestFuture
+            .timeout(Duration(milliseconds: options.connectTimeout));
+      } else {
+        request = await requestFuture;
+      }
+
       //Set Headers
       options.headers.forEach((k, v) => request.headers.set(k, v));
     } on SocketException catch (e) {

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -44,11 +44,15 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
     HttpClientRequest request;
     try {
-      request = await requestFuture;
+      request = await requestFuture
+          .timeout(Duration(milliseconds: options.connectTimeout));
       //Set Headers
       options.headers.forEach((k, v) => request.headers.set(k, v));
     } on SocketException catch (e) {
       if (e.message.contains('timed out')) _throwConnectingTimeout();
+      rethrow;
+    } on TimeoutException {
+      _throwConnectingTimeout();
       rethrow;
     }
 

--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -58,7 +58,6 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       rethrow;
     } on TimeoutException {
       _throwConnectingTimeout();
-      rethrow;
     }
 
     request.followRedirects = options.followRedirects;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #844 

### Pull Request Description
When a user was connected to wifi while there was no internet connection available, Dio would not throw a CONNECT_TIMEOUT exception.
This commit fixes that issue.

