### PR TITLE
Prevents Bad State: No Element from being thrown

### DIFF
--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -93,9 +93,15 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
     if (requestStream == null) {
       xhr.send();
     } else {
-      requestStream
-          .reduce((a, b) => Uint8List.fromList([...a, ...b]))
-          .then(xhr.send);
+      requestStream.isEmpty.then((isEmpty) {
+        if (isEmpty) {
+          xhr.send();
+        } else {
+          requestStream
+            .reduce((a, b) => Uint8List.fromList([...a, ...b]))
+            .then(xhr.send);
+        }
+      });
     }
 
     return completer.future.whenComplete(() {


### PR DESCRIPTION
If the reduce method is called on an empty stream (like Stream.empty()), a Bad State: No Element exception is thrown. This change adds a check to determine if the stream is empty before sending the request. If the stream is empty, the request is sent but if the stream is not empty, the stream is reduced before being sent.

I ran into this issue when using doing a get request on flutter web.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

When using dio on web, like in dio's flutter example, a get request will fail and return a Bad State: No Element exception. This is caused by the reduce method being called on an empty stream. This pull requests adds a check to determine if the stream is empty before reducing it to prevent a Bad State: No element error.

