### PR TITLE
Export DioMixin

### DIFF
--- a/dio/lib/dio.dart
+++ b/dio/lib/dio.dart
@@ -6,6 +6,7 @@
 library dio;
 
 export 'src/dio.dart';
+export 'src/dio_mixin.dart';
 export 'src/form_data.dart';
 export 'src/dio_error.dart';
 export 'src/transformer.dart';


### PR DESCRIPTION
Migration to null safety accidentally hid the DioMixin class from the public facing API. This change would re-expose it to the public facing API.

### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
The null-safety pull request hid DioMixin from the public facing API. This pull request exports 'src/dio_mixin.dart' to the public facing API.
