### PR TITLE
docs: fix inconsistent comments for `download`

### DIFF
--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -205,9 +205,9 @@ abstract class Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg "xs.jpg"
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
-  ///   await dio.download(url,(HttpHeaders responseHeaders){
+  ///   await dio.download(url,(Headers responseHeaders){
   ///      ...
   ///      return "...";
   ///    });
@@ -255,9 +255,9 @@ abstract class Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg "xs.jpg"
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
-  ///   await dio.downloadUri(uri,(HttpHeaders responseHeaders){
+  ///   await dio.downloadUri(uri,(Headers responseHeaders){
   ///      ...
   ///      return "...";
   ///    });
@@ -324,5 +324,3 @@ abstract class Dio {
 
   Future<Response<T>> fetch<T>(RequestOptions requestOptions);
 }
-
-

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -328,9 +328,9 @@ abstract class DioMixin implements Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg 'xs.jpg'
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
-  ///   await dio.download(url,(HttpHeaders responseHeaders){
+  ///   await dio.download(url,(Headers responseHeaders){
   ///      ...
   ///      return '...';
   ///    });
@@ -381,9 +381,9 @@ abstract class DioMixin implements Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg 'xs.jpg'
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
-  ///   await dio.downloadUri(uri,(HttpHeaders responseHeaders){
+  ///   await dio.downloadUri(uri,(Headers responseHeaders){
   ///      ...
   ///      return '...';
   ///    });

--- a/dio/lib/src/entry/dio_for_native.dart
+++ b/dio/lib/src/entry/dio_for_native.dart
@@ -28,7 +28,7 @@ class DioForNative with DioMixin implements Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg "xs.jpg"
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
   ///   await dio.download(url,(Headers responseHeaders){
   ///      ...
@@ -105,7 +105,7 @@ class DioForNative with DioMixin implements Dio {
     File file;
     if (savePath is Function) {
       assert(savePath is String Function(Headers),
-          'savePath callback type must be `String Function(HttpHeaders)`');
+          'savePath callback type must be `String Function(Headers)`');
       file = File(savePath(response.headers));
     } else {
       file = File(savePath.toString());
@@ -226,7 +226,7 @@ class DioForNative with DioMixin implements Dio {
   ///  [savePath]: The path to save the downloading file later. it can be a String or
   ///  a callback:
   ///  1. A path with String type, eg 'xs.jpg'
-  ///  2. A callback `String Function(HttpHeaders responseHeaders)`; for example:
+  ///  2. A callback `String Function(Headers responseHeaders)`; for example:
   ///  ```dart
   ///   await dio.downloadUri(uri,(Headers responseHeaders){
   ///      ...


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #856 . The assertion in the code is now consistent with the comments thus the docs for `download` API.

Details: param `savePath` takes either a `String` or `String Function(Headers)` but not `String Function(HttpHeaders)`.