### PR TITLE
fix issue 

### DIFF
--- a/dio/lib/src/response.dart
+++ b/dio/lib/src/response.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import '../dio.dart';
 import 'options.dart';
 import 'headers.dart';
 import 'redirect_record.dart';
@@ -8,7 +9,7 @@ class Response<T> {
   Response({
     this.data,
     Headers? headers,
-    required this.request,
+    RequestOptions? request,
     this.isRedirect,
     this.statusCode,
     this.statusMessage,
@@ -18,6 +19,7 @@ class Response<T> {
     this.headers = headers ?? Headers();
     this.extra = extra ?? {};
     this.redirects = redirects ?? [];
+    this.request = request ?? RequestOptions(path: '');
   }
 
   /// Response body. may have been transformed, please refer to [ResponseType].

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
-version: 4.0.0-beta7
+version: 4.0.0-beta8
 homepage: https://github.com/flutterchina/dio
 
 environment:


### PR DESCRIPTION
### Issue fix

```
dio-4.0.0-beta7/lib/src/response.dart:11:10: Error: The parameter 'request' can't have a value of 'null' because of its type 'RequestOptions', but the implicit default value is 'null'.

'RequestOptions' is from 'package:dio/src/options.dart' ('dio-4.0.0-beta7/lib/src/options.dart').
Try adding either an explicit non-'null' default value or the 'required' modifier.
    this.request,
```