### PR TITLE
Typo fix

### DIFF
--- a/dio/lib/src/dio_error.dart
+++ b/dio/lib/src/dio_error.dart
@@ -41,7 +41,7 @@ class DioError implements Exception {
   DioErrorType type;
 
   /// The original error/exception object; It's usually not null when `type`
-  /// is DioErrorType.DEFAULT
+  /// is DioErrorType.other
   dynamic? error;
 
   StackTrace? _stackTrace;


### PR DESCRIPTION
Since DioErrorType.DEFAULT has been renamed to DioErrorType.other, line 44 should reflect that change
