### PR TITLE
Replay request

### DIFF
--- a/dio/lib/src/interceptors/replay.dart
+++ b/dio/lib/src/interceptors/replay.dart
@@ -1,0 +1,45 @@
+import 'package:dio/dio.dart';
+
+/// [ReplayInterceptor] is used to allow a request to be re-sent.
+/// The client used here can be either the main one used to create the original
+/// request or another one created on the side for different purpose. But at the
+/// end. The request will be forwarded to the client that initiated the original
+/// request where [RequestOptions] is taken from
+class ReplayInterceptor extends Interceptor {
+  Dio? _client;
+
+  ReplayInterceptor({Dio? client}) {
+    _client = client;
+  }
+
+  set client(Dio value) {
+    _client = value;
+  }
+
+  ///[ResponseInterceptorHandler] is need to forward the final response
+  ///to the initial dio client
+  void replay(
+      RequestOptions requestOptions, ResponseInterceptorHandler handler) {
+    replayAndReturn(requestOptions).then((value) {
+      onResponse(value, handler);
+    });
+  }
+
+  /// [RequestOptions] comes from the original request. It is needed so
+  /// parameters will be extracted from it to replay the request
+  /// Left public because some might want to handle the response differently
+  Future<Response> replayAndReturn(RequestOptions requestOptions) {
+    if (_client != null) {
+      var options = Options.fromRequestOptions(requestOptions);
+      return _client!.request(requestOptions.path,
+          data: requestOptions.data,
+          cancelToken: requestOptions.cancelToken,
+          onSendProgress: requestOptions.onSendProgress,
+          onReceiveProgress: requestOptions.onReceiveProgress,
+          queryParameters: requestOptions.queryParameters,
+          options: options);
+    } else {
+      throw ArgumentError('Tried to replay on a null Dio client');
+    }
+  }
+}

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -333,6 +333,24 @@ class Options {
     return requestOptions;
   }
 
+  /// Create an [Options] object from [RequestOptions]. Useful to replay requests
+  Options.fromRequestOptions(RequestOptions requestOptions) {
+    method = requestOptions.method;
+    sendTimeout = requestOptions.sendTimeout;
+    receiveTimeout = requestOptions.receiveTimeout;
+    extra = requestOptions.extra;
+    headers = requestOptions.headers;
+    responseType = requestOptions.responseType;
+    contentType = requestOptions.contentType;
+    validateStatus = requestOptions.validateStatus;
+    receiveDataWhenStatusError = requestOptions.receiveDataWhenStatusError;
+    followRedirects = requestOptions.followRedirects;
+    maxRedirects = requestOptions.maxRedirects;
+    requestEncoder = requestOptions.requestEncoder;
+    responseDecoder = requestOptions.responseDecoder;
+    listFormat = requestOptions.listFormat;
+  }
+
   /// Http method.
   String? method;
 


### PR DESCRIPTION
…tions from RequestOptions (options.dart)

It is useful in cases when the response indicates an expired token. The interceptor can take the RequestOptions from a previous request and replay the request after updating the token(probably better done in the same interceptor).

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [x ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

