### PR TITLE
Export ListParam and add toString/equals/hashCode

### DIFF
--- a/dio/lib/dio.dart
+++ b/dio/lib/dio.dart
@@ -5,17 +5,18 @@
 /// A open source project authorized by [https://flutterchina.club](https://flutterchina.club).
 library dio;
 
+export 'src/adapter.dart';
+export 'src/cancel_token.dart';
 export 'src/dio.dart';
+export 'src/dio_error.dart';
 export 'src/dio_mixin.dart';
 export 'src/form_data.dart';
-export 'src/dio_error.dart';
-export 'src/transformer.dart';
-export 'src/interceptor.dart' hide InterceptorState, InterceptorResultType;
-export 'src/options.dart';
-export 'src/response.dart';
-export 'src/cancel_token.dart';
-export 'src/multipart_file.dart';
-export 'src/adapter.dart';
 export 'src/headers.dart';
+export 'src/interceptor.dart' hide InterceptorState, InterceptorResultType;
 export 'src/interceptors/log.dart';
+export 'src/multipart_file.dart';
+export 'src/options.dart';
+export 'src/parameter.dart';
 export 'src/redirect_record.dart';
+export 'src/response.dart';
+export 'src/transformer.dart';

--- a/dio/lib/src/parameter.dart
+++ b/dio/lib/src/parameter.dart
@@ -5,4 +5,20 @@ class ListParam<T> {
   List<T> value;
 
   ListParam(this.value, this.format);
+
+  @override
+  String toString() {
+    return 'ListParam{format: $format, value: $value}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ListParam &&
+          runtimeType == other.runtimeType &&
+          format == other.format &&
+          value == other.value;
+
+  @override
+  int get hashCode => format.hashCode ^ value.hashCode;
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes the missing export of `ListParam`

### Pull Request Description

* export `ListParam` and add toString/equals/hashCode
* order imports in main file
