### PR TITLE
Fix assert failure when call BaseOptions.copyWith()

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -590,8 +590,9 @@ class _RequestConfig {
     var contentTypeInHeader =
         this.headers.containsKey(Headers.contentTypeHeader);
     assert(
-      !(contentType != null && contentTypeInHeader),
-      'You cannot set both contentType param and a content-type header',
+      !(contentType != null && contentTypeInHeader) ||
+          this.headers[Headers.contentTypeHeader] == contentType,
+      'You cannot set different values for contentType param and a content-type header',
     );
 
     this.method = method ?? 'GET';

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -111,9 +111,11 @@ void main() {
 
     var bo1 = BaseOptions(contentType: contentType);
     var bo2 = BaseOptions(headers: headers);
+    var bo3 = BaseOptions();
 
     assert(bo1.headers['content-type'] == contentType);
     assert(bo2.headers['content-type'] == contentType);
+    assert(bo3.headers['content-type'] == Headers.jsonContentType);
 
     try {
       bo1.copyWith(headers: headers);
@@ -128,6 +130,8 @@ void main() {
     } catch (e) {
       //
     }
+
+    bo3.copyWith();
 
     /// options
     try {
@@ -190,6 +194,9 @@ void main() {
     } catch (e) {
       //
     }
+
+    var ro3 = RequestOptions(path: '');
+    ro3.copyWith();
   });
 
   test('#test default content-type', () async {


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #1133 

### Pull Request Description

Added check if `contentType` is equals to content type in `headers` and do not throw assert error in that case.

