### PR TITLE
fix queryParameter unexpectedly overridden by BaseOption

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -283,8 +283,8 @@ class Options {
     ProgressCallback? onReceiveProgress,
   }) {
     var query = <String, dynamic>{};
-    if (queryParameters != null) query.addAll(queryParameters);
     query.addAll(baseOpt.queryParameters);
+    if (queryParameters != null) query.addAll(queryParameters);
 
     var _headers = caseInsensitiveKeyMap(baseOpt.headers);
     _headers.remove(Headers.contentTypeHeader);


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: 
- #1169 

### Pull Request Description

`BaseOptions.queryParameters` should be overridden by passed `queryParameters`.

