### PR TITLE
Fix/index out of bounds

### DIFF
--- a/dio/lib/src/dio_error.dart
+++ b/dio/lib/src/dio_error.dart
@@ -56,7 +56,7 @@ class DioError implements Exception {
   String toString() {
     var msg = 'DioError [$type]: $message';
     if (_stackTrace != null) {
-      msg += '\n${stackTrace}';
+      msg += '\n$stackTrace';
     }
     return msg;
   }

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -636,7 +636,7 @@ abstract class DioMixin implements Dio {
       );
       responseBody.headers = responseBody.headers;
       var headers = Headers.fromMap(responseBody.headers);
-      var ret = Response(
+      var ret = Response<T>(
         headers: headers,
         requestOptions: reqOpt,
         redirects: responseBody.redirects ?? [],
@@ -664,8 +664,7 @@ abstract class DioMixin implements Dio {
       }
       checkCancelled(cancelToken);
       if (statusOk) {
-        return checkIfNeedEnqueue(interceptors.responseLock, () => ret)
-            as Response<T>;
+        return checkIfNeedEnqueue(interceptors.responseLock, () => ret);
       } else {
         throw DioError(
           requestOptions: reqOpt,
@@ -787,9 +786,12 @@ abstract class DioMixin implements Dio {
     return options;
   }
 
-  static FutureOr checkIfNeedEnqueue(Lock lock, EnqueueCallback callback) {
+  static FutureOr<T> checkIfNeedEnqueue<T>(
+    Lock lock,
+    EnqueueCallback<T> callback,
+  ) {
     if (lock.locked) {
-      return lock.enqueue(callback);
+      return lock.enqueue(callback)!;
     } else {
       return callback();
     }

--- a/dio/lib/src/interceptor.dart
+++ b/dio/lib/src/interceptor.dart
@@ -5,7 +5,7 @@ import 'options.dart';
 import 'dio_error.dart';
 import 'response.dart';
 
-typedef EnqueueCallback = FutureOr Function();
+typedef EnqueueCallback<T> = FutureOr<T> Function();
 
 /// Add lock/unlock API for interceptors.
 class Lock {
@@ -49,7 +49,7 @@ class Lock {
   ///
   /// [callback] the function  will return a `Future`
   /// @nodoc
-  Future? enqueue(EnqueueCallback callback) {
+  Future<T>? enqueue<T>(EnqueueCallback<T> callback) {
     if (locked) {
       // we use a future as a queue
       return _lock!.then((d) => callback());

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import '../dio_error.dart';
 import '../interceptor.dart';
 import '../options.dart';

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -537,7 +537,9 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     if (!_url.startsWith(RegExp(r'https?:'))) {
       _url = baseUrl + _url;
       var s = _url.split(':/');
-      _url = s[0] + ':/' + s[1].replaceAll('//', '/');
+      if (s.length == 2) {
+        _url = s[0] + ':/' + s[1].replaceAll('//', '/');
+      }
     }
     var query = Transformer.urlEncodeMap(queryParameters, listFormat);
     if (query.isNotEmpty) {

--- a/plugins/cookie_manager/example/example.dart
+++ b/plugins/cookie_manager/example/example.dart
@@ -1,14 +1,14 @@
+import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
-import 'package:cookie_jar/cookie_jar.dart';
 
-main() async {
+void main() async {
   var dio = Dio();
   var cookieJar = CookieJar();
   dio.interceptors.add(CookieManager(cookieJar));
-  await dio.get("https://baidu.com/");
+  await dio.get('https://baidu.com/');
   // Print cookies
-  print(cookieJar.loadForRequest(Uri.parse("https://baidu.com/")));
+  print(cookieJar.loadForRequest(Uri.parse('https://baidu.com/')));
   // second request with the cookie
-  await dio.get("https://baidu.com/");
+  await dio.get('https://baidu.com/');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dio_example
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
 version: 0.0.1
+publish_to: "none"
 homepage: https://github.com/flutterchina/dio
 author: wendux <824783146@qq.com>
 environment:
@@ -17,3 +18,10 @@ dependencies:
   pedantic: ^1.10.0
   test_coverage: ^0.5.0
 
+dependency_overrides:
+  dio:
+    path: dio
+  dio_http2_adapter:
+    path: plugins/http2_adapter
+  dio_cookie_manager:
+    path: plugins/cookie_manager


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Depends On

This PR should not be merged before #1224. 

### Pull Request Description

Fixes index out of bounds issue caused when getting `BaseOptions.uri` property. The error is thrown when the `_uri` does not contains `":/"` pattern which might be caused when not providing `baseUrl` for the request. 

```dart
_url = baseUrl + _url;
var s = _url.split(':/'); // this might return array of just 1 string if the _url does not contains search pattern (":/").
_url = s[0] + ':/' + s[1].replaceAll('//', '/');
```

I know that request URLs should contain request protocol / scheme part, but throwing out of bounds error might cause confusion to the end user. I had actually experienced that. I had written an interceptor that logs all the requests responses and failed request details to the console. I was printing error.requestOptions.uri to the console. But when I see that there's some weird error caused by out of bounds issue it thought a few hours to figure out that the error was originally caused by the logger interceptor itself not the callee. (It also had an error but the error interceptor's error were thrown first and the original error is not logged.)