### PR TITLE
README - fix error.response condition in error catch block

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ try {
 } on DioError catch (e) {
   // The request was made and the server responded with a status code
   // that falls out of the range of 2xx and is also not 304.
-  if (e.response) {
+  if (e.response != null) {
     print(e.response.data)
     print(e.response.headers)
     print(e.response.request)


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

With Dart SDK >= 2.13.0 ( probably lower ones too ), error.response condition shown in Readme is not valid. 

Actual version:
```dart
try {
  //404
  await dio.get('https://wendux.github.io/xsddddd');
} on DioError catch (e) {
  // The request was made and the server responded with a status code
  // that falls out of the range of 2xx and is also not 304.
  if (e.response) {
    print(e.response.data)
    print(e.response.headers)
    print(e.response.request)
  } else {
    // Something happened in setting up or sending the request that triggered an Error
    print(e.request)
    print(e.message)
  }
}
```
Current documentation triggers an error: `Conditions must have a static type of 'bool'`

DioError scheme shows it is a nullable:
```dart
  /// Response info, it may be `null` if the request can't reach to
  /// the http server, for example, occurring a dns error, network is not available.
  Response? response;
 ```
 
 Thus the simplest solution is to add `!= null` in the condition. 
 ```dart
 try {
  //404
  await dio.get('https://wendux.github.io/xsddddd');
} on DioError catch (e) {
  // The request was made and the server responded with a status code
  // that falls out of the range of 2xx and is also not 304.
  if (e.response != null) {
    print(e.response.data)
    print(e.response.headers)
    print(e.response.request)
  } else {
    // Something happened in setting up or sending the request that triggered an Error
    print(e.request)
    print(e.message)
  }
}
```

...

