### PR TITLE
do not override the content type if set

### DIFF
--- a/dio/lib/src/transformer.dart
+++ b/dio/lib/src/transformer.dart
@@ -67,7 +67,7 @@ class DefaultTransformer extends Transformer {
       if (_isJsonMime(options.contentType)) {
         return json.encode(options.data);
       } else if (data is Map) {
-        options.contentType = Headers.formUrlEncodedContentType;
+        options.contentType = options.contentType ?? Headers.formUrlEncodedContentType;
         return Transformer.urlEncodeMap(data);
       }
     }


### PR DESCRIPTION
Dio is overwriting the contentType header if one is set in the options. It should not overwrite the content-type if a header is explicitly set for that.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

