### PR TITLE
Enable multipart files to support additional headers

### DIFF
--- a/dio/lib/src/form_data.dart
+++ b/dio/lib/src/form_data.dart
@@ -22,7 +22,7 @@ class FormData {
   final _newlineRegExp = RegExp(r'\r\n|\r|\n');
 
   /// The form fields to send for this request.
-  final fields = <MapEntry<String, String>>[];
+  final fields = <MapEntry<String, String>>[]; // todo (which will probably require a breaking change): support additional headers for fields
 
   /// The [files].
   final files = <MapEntry<String, MultipartFile>>[];
@@ -88,6 +88,14 @@ class FormData {
     }
     header = '$header\r\n'
         'content-type: ${file.contentType}';
+    if (file.headers != null) { // append additional headers
+      file.headers?.forEach((key, values) {
+        values.forEach((value) {
+          header = '$header\r\n'
+              '$key: $value';
+        });
+      });
+    }
     return '$header\r\n\r\n';
   }
 

--- a/dio/lib/src/multipart_file.dart
+++ b/dio/lib/src/multipart_file.dart
@@ -21,6 +21,9 @@ class MultipartFile {
   /// The basename of the file. May be null.
   final String? filename;
 
+  /// The additional headers the file has. May be null.
+  final Map<String, List<String>>? headers;
+
   /// The content-type of the file. Defaults to `application/octet-stream`.
   final MediaType? contentType;
 
@@ -42,6 +45,7 @@ class MultipartFile {
     this.length, {
     this.filename,
     MediaType? contentType,
+    this.headers,
   })  : _stream = stream,
         contentType = contentType ?? MediaType('application', 'octet-stream');
 
@@ -53,6 +57,7 @@ class MultipartFile {
     List<int> value, {
     String? filename,
     MediaType? contentType,
+    final Map<String, List<String>>? headers,
   }) {
     var stream = Stream.fromIterable([value]);
     return MultipartFile(
@@ -60,6 +65,7 @@ class MultipartFile {
       value.length,
       filename: filename,
       contentType: contentType,
+      headers: headers,
     );
   }
 
@@ -73,6 +79,7 @@ class MultipartFile {
     String value, {
     String? filename,
     MediaType? contentType,
+    final Map<String, List<String>>? headers,
   }) {
     contentType ??= MediaType('text', 'plain');
     var encoding = encodingForCharset(contentType.parameters['charset'], utf8);
@@ -82,6 +89,7 @@ class MultipartFile {
       encoding.encode(value),
       filename: filename,
       contentType: contentType,
+      headers: headers,
     );
   }
 
@@ -97,22 +105,26 @@ class MultipartFile {
     String filePath, {
     String? filename,
     MediaType? contentType,
+    final Map<String, List<String>>? headers,
   }) =>
       multipartFileFromPath(
         filePath,
         filename: filename,
         contentType: contentType,
+        headers: headers,
       );
 
   static MultipartFile fromFileSync(
     String filePath, {
     String? filename,
     MediaType? contentType,
+    final Map<String, List<String>>? headers,
   }) =>
       multipartFileFromPathSync(
         filePath,
         filename: filename,
         contentType: contentType,
+        headers: headers,
       );
 
   Stream<List<int>> finalize() {

--- a/dio/lib/src/multipart_file_io.dart
+++ b/dio/lib/src/multipart_file_io.dart
@@ -8,6 +8,7 @@ Future<MultipartFile> multipartFileFromPath(
   String filePath, {
   String? filename,
   MediaType? contentType,
+  final Map<String, List<String>>? headers,
 }) async {
   filename ??= p.basename(filePath);
   var file = File(filePath);
@@ -18,6 +19,7 @@ Future<MultipartFile> multipartFileFromPath(
     length,
     filename: filename,
     contentType: contentType,
+    headers: headers,
   );
 }
 
@@ -25,6 +27,7 @@ MultipartFile multipartFileFromPathSync(
   String filePath, {
   String? filename,
   MediaType? contentType,
+  final Map<String, List<String>>? headers,
 }) {
   filename ??= p.basename(filePath);
   var file = File(filePath);
@@ -35,5 +38,6 @@ MultipartFile multipartFileFromPathSync(
     length,
     filename: filename,
     contentType: contentType,
+    headers: headers,
   );
 }

--- a/dio/lib/src/multipart_file_stub.dart
+++ b/dio/lib/src/multipart_file_stub.dart
@@ -6,9 +6,9 @@ final _err = UnsupportedError(
     'MultipartFile is only supported where dart:io is available.');
 
 Future<MultipartFile> multipartFileFromPath(String filePath,
-        {String? filename, MediaType? contentType}) =>
+        {String? filename, MediaType? contentType, final Map<String, List<String>>? headers}) =>
     throw _err;
 
 MultipartFile multipartFileFromPathSync(String filePath,
-        {String? filename, MediaType? contentType}) =>
+        {String? filename, MediaType? contentType, final Map<String, List<String>>? headers}) =>
     throw _err;

--- a/dio/test/_formdata
+++ b/dio/test/_formdata
@@ -9,11 +9,13 @@ content-disposition: form-data; name="age"
 ----dio-boundary-3788753558
 content-disposition: form-data; name="file"
 content-type: text/plain; charset=utf-8
+test: a
 
 hello world.
 ----dio-boundary-3788753558
 content-disposition: form-data; name="files"; filename="1.txt"
 content-type: application/octet-stream
+test: b
 
 你好世界，
 我很好人类
@@ -22,6 +24,7 @@ content-type: application/octet-stream
 ----dio-boundary-3788753558
 content-disposition: form-data; name="files"; filename="2.txt"
 content-type: application/octet-stream
+test: c
 
 你好世界，
 我很好人类

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -12,15 +12,17 @@ void main() async {
     var fm = FormData.fromMap({
       'name': 'wendux',
       'age': 25,
-      'file': MultipartFile.fromString('hello world.'),
+      'file': MultipartFile.fromString('hello world.', headers: { 'test': <String>['a'] }),
       'files': [
         await MultipartFile.fromFile(
           '../dio/test/_testfile',
           filename: '1.txt',
+          headers: { 'test': <String>['b'] },
         ),
         MultipartFile.fromFileSync(
           '../dio/test/_testfile',
           filename: '2.txt',
+            headers: { 'test': <String>['c'] },
         ),
       ]
     });
@@ -41,13 +43,14 @@ void main() async {
     fm1.fields.add(MapEntry('age', '25'));
     fm1.files.add(MapEntry(
       'file',
-      MultipartFile.fromString('hello world.'),
+      MultipartFile.fromString('hello world.', headers: { 'test': <String>['a'] }),
     ));
     fm1.files.add(MapEntry(
       'files',
       await MultipartFile.fromFile(
         '../dio/test/_testfile',
         filename: '1.txt',
+          headers: { 'test': <String>['b'] }
       ),
     ));
     fm1.files.add(MapEntry(
@@ -55,6 +58,7 @@ void main() async {
       await MultipartFile.fromFile(
         '../dio/test/_testfile',
         filename: '2.txt',
+          headers: { 'test': <String>['c'] }
       ),
     ));
     assert(fmStr.length == fm1.length);


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description

Enables adding additional headers (outside Content-Type) to files in multipart requests [(akin to Golang's multipart support)](https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/mime/multipart/writer.go;l=97)
