### PR TITLE
FIX : Issue #1282

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -42,6 +42,14 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       );
     }
 
+    void _throwReceivingTimeout() {
+      throw DioError(
+        requestOptions: options,
+        error: 'Receiving data timeout[${options.receiveTimeout}ms]',
+        type: DioErrorType.receiveTimeout,
+      );
+    }
+
     late HttpClientRequest request;
     try {
       if (options.connectTimeout > 0) {
@@ -70,14 +78,14 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       await request.addStream(requestStream);
     }
     var future = request.close();
-    if (options.connectTimeout > 0) {
-      future = future.timeout(Duration(milliseconds: options.connectTimeout));
+    if (options.receiveTimeout > 0) {
+      future = future.timeout(Duration(milliseconds: options.receiveTimeout));
     }
     late HttpClientResponse responseStream;
     try {
       responseStream = await future;
     } on TimeoutException {
-      _throwConnectingTimeout();
+      _throwReceivingTimeout();
     }
 
     var stream =


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
I think connectTimeOut should only affect the process of making a connection.
However, it seems to have an effect on the process of getting a response too.

So I made a revision in  io_adapter.dart like this.
1. After get a response from request.close(), set timeout by receiveTimeout instead of connectTimeout.
2. _throwReceivingTimeout appended. it is used when an exception occurs while waiting for a response.