### PR TITLE
Fixed #946: Preventing bad state on CancelToken

### DIFF
--- a/dio/lib/src/cancel_token.dart
+++ b/dio/lib/src/cancel_token.dart
@@ -40,6 +40,9 @@ class CancelToken {
       requestOptions: requestOptions ?? RequestOptions(path: ''),
     );
     _cancelError!.stackTrace = StackTrace.current;
-    _completer.complete(_cancelError);
+
+    if(!_completer.isCompleted){
+      _completer.complete(_cancelError);
+    }
   }
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: #946

### Pull Request Description
The issue #946 was closed by the stale bot, but i had the same problem recently.
So I have added a verification to only call _completer.complete() if the _completer hasn't already completed.
...

