### PR TITLE
Use catchError to mark thrown error as handled

### DIFF
--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -588,7 +588,7 @@ abstract class DioMixin implements Dio {
           handler.reject(e as DioError, true);
         },
       ).catchError((e) {
-        // fix for: then() method's onError not viewed by the debugger as a proper catch block for DioError
+        // catchError because the debugger is not finding a proper catch block for DioError
         handler.reject(e as DioError, true);
       });
     }));

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -587,7 +587,10 @@ abstract class DioMixin implements Dio {
         onError: (e) {
           handler.reject(e as DioError, true);
         },
-      );
+      ).catchError((e) {
+        // fix for: then() method's onError not viewed by the debugger as a proper catch block for DioError
+        handler.reject(e as DioError, true);
+      });
     }));
 
     // Add response interceptors to request flow

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
-version: 4.0.1
+version: 4.0.2
 homepage: https://github.com/flutterchina/dio
 
 environment:


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues:
Debugger will halt execution while debugging an app that uses Dio to generate requests. This is really an issue with Dart that is known and is somewhat being worked on and this is a quickfix for everyone using Dio with debugger.

### Pull Request Description
Use catchError method to let the debugger know that the thrown DioError will be caught so it doesn't hold execution while debugging.
Fix for flutterchina#1306

