### PR TITLE
Null data

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 4.0.4
+- Fix fetching null data in a response
 
 # 4.0.3
 - fix #1311

--- a/dio/lib/src/dio_mixin.dart
+++ b/dio/lib/src/dio_mixin.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:typed_data';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'adapter.dart';
 import 'cancel_token.dart';
@@ -844,7 +844,7 @@ abstract class DioMixin implements Dio {
         requestOptions: requestOptions ?? RequestOptions(path: ''),
       );
     } else if (response is! Response<T>) {
-      T? data = response.data as T;
+      T? data = response.data as T?;
       return Response<T>(
         data: data,
         headers: response.headers,

--- a/dio/test/dio_mixin_test.dart
+++ b/dio/test/dio_mixin_test.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('#assureResponse', () {
+    final untypedResponse = Response<dynamic>(
+      requestOptions: RequestOptions(path: ''),
+      data: null,
+    );
+    expect(untypedResponse is Response<int?>, isFalse);
+
+    final typedResponse = DioMixin.assureResponse<int?>(untypedResponse);
+    expect(typedResponse.data, isNull);
+  });
+}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues:

Nullable data responses were being cast to `T` instead of `T?`, which throws a runtime error when the data response is `null`.

### Pull Request Description

Instead of receiving a `null` response, fetching the data throws a runtime error because the code was attempting to cast a null value to a non-nullable type.