### PR TITLE
Update the Simple interceptor example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,9 @@ class CustomInterceptors extends Interceptor {
     return super.onRequest(options, handler);
   }
   @override
-  Future onResponse(Response response, ResponseInterceptorHandler handler) {
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
     print('RESPONSE[${response.statusCode}] => PATH: ${response.requestOptions.path}');
-    return super.onResponse(response, handler);
+    super.onResponse(response, handler);
   }
   @override
   Future onError(DioError err, ErrorInterceptorHandler handler) {


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: README out of date for onResponse function example

### Pull Request Description

- Changed the example onResponse function return under "Simple interceptor example" to match the latest code.
- onResponse does not return a Future any more, it is now a void function.

