### PR TITLE
Make it possible to instantiate a universal adapter

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
 - `ResponseBody.statusCode` is now non-nullable
+- add option to instanciate a `HttpClientAdapter`, which is platform independent
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
 - `ResponseBody.statusCode` is now non-nullable
-- add option to instanciate a `HttpClientAdapter`, which is platform independent
+- add option to instantiate a `HttpClientAdapter`, which is platform independent
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/README.md
+++ b/dio/README.md
@@ -650,12 +650,13 @@ HttpClientAdapter is a bridge between Dio and HttpClient.
 
 Dio implements standard and friendly API  for developer.
 
-HttpClient: It is the real object that makes Http requests.
+HttpClientAdapter: It is the real object that makes Http requests.
 
-We can use any HttpClient not just `dart:io:HttpClient` to make the Http request.  And  all we need is providing a `HttpClientAdapter`. The default HttpClientAdapter for Dio is `DefaultHttpClientAdapter`.
+If you want to customize the `HttpClientAdapter` you should instead use
+either `DefaultHttpClientAdapter` on `dart:io` platforms or `BrowserHttpClientAdapter` on `dart:html` platforms.
 
 ```dart
-dio.httpClientAdapter = new DefaultHttpClientAdapter();
+dio.httpClientAdapter = new HttpClientAdapter();
 ```
 
 [Here](https://github.com/flutterchina/dio/blob/master/example/adapter.dart) is a simple example to custom adapter. 

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
-
+import 'package:dio/src/adapters/universal_adapter.dart';
 import 'options.dart';
 import 'redirect_record.dart';
 
@@ -14,12 +14,18 @@ import 'redirect_record.dart';
 /// We can use any HttpClient not just "dart:io:HttpClient" to
 /// make the Http request. All we need is providing a [HttpClientAdapter].
 ///
-/// The default HttpClientAdapter for Dio is [DefaultHttpClientAdapter].
+/// The default HttpClientAdapter for Dio is [HttpClientAdapter].
+///
+/// If you want to customize the `HttpClientAdapter` you should instead use
+/// either `DefaultHttpClientAdapter` on `dart:io` platforms
+/// or `BrowserHttpClientAdapter` on `dart:html` platforms.
 ///
 /// ```dart
-/// dio.httpClientAdapter = DefaultHttpClientAdapter();
+/// dio.httpClientAdapter = HttpClientAdapter();
 /// ```
 abstract class HttpClientAdapter {
+  factory HttpClientAdapter() => createAdapter();
+
   /// We should implement this method to make real http requests.
   ///
   /// [options]: The request options

--- a/dio/lib/src/adapters/universal_adapter.dart
+++ b/dio/lib/src/adapters/universal_adapter.dart
@@ -1,0 +1,6 @@
+import 'package:dio/dio.dart';
+
+import 'io_adapter.dart' if (dart.library.html) 'browser_adapter.dart'
+    as adapter;
+
+HttpClientAdapter createAdapter() => adapter.createAdapter();

--- a/dio/test/echo_adapter.dart
+++ b/dio/test/echo_adapter.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 
-class EchoAdapter extends HttpClientAdapter {
+class EchoAdapter implements HttpClientAdapter {
   static const mockHost = 'mockserver';
   static const mockBase = 'http://$mockHost';
   final _adapter = DefaultHttpClientAdapter();

--- a/dio/test/mock_adapter.dart
+++ b/dio/test/mock_adapter.dart
@@ -6,7 +6,7 @@ import 'dart:typed_data';
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 
-class MockAdapter extends HttpClientAdapter {
+class MockAdapter implements HttpClientAdapter {
   static const mockHost = 'mockserver';
   static const mockBase = 'http://$mockHost';
   final _adapter = DefaultHttpClientAdapter();

--- a/example/lib/adapter.dart
+++ b/example/lib/adapter.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
-import 'package:dio/adapter.dart';
 
-class MyAdapter extends HttpClientAdapter {
-  final DefaultHttpClientAdapter _adapter = DefaultHttpClientAdapter();
+class MyAdapter implements HttpClientAdapter {
+  final HttpClientAdapter _adapter = HttpClientAdapter();
 
   @override
   Future<ResponseBody> fetch(RequestOptions options,

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -11,7 +11,7 @@ part 'connection_manager.dart';
 part 'connection_manager_imp.dart';
 
 /// A Dio HttpAdapter which implements Http/2.0.
-class Http2Adapter extends HttpClientAdapter {
+class Http2Adapter implements HttpClientAdapter {
   final ConnectionManager _connectionMgr;
 
   Http2Adapter(ConnectionManager? connectionManager)


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description

This PR makes it possible to instantiate a `HttpClientAdapter` which is platform independent.

Partly fixes #1362

This is a breaking change if people decided to extend `HttpClientAdapter`.
