### PR TITLE
Make `ResponseBody.statusCode` non-nullable

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
+- `ResponseBody.statusCode` is now non-nullable
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -61,10 +61,10 @@ class ResponseBody {
   Stream<Uint8List> stream;
 
   /// the response headers
-  late Map<String, List<String>> headers;
+  Map<String, List<String>> headers;
 
   /// Http status code
-  int? statusCode;
+  int statusCode;
 
   /// Returns the reason phrase associated with the status code.
   /// The reason phrase must be set before the body is written

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -53,7 +53,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       completer.complete(
         ResponseBody.fromBytes(
           body,
-          xhr.status,
+          xhr.status!,
           headers: xhr.responseHeaders.map((k, v) => MapEntry(k, v.split(','))),
           statusMessage: xhr.statusText,
           isRedirect: xhr.status == 302 || xhr.status == 301,


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

### Pull Request Description

This makes `ResponseBody.statusCode` non-nullable. It improves the API a little bit.
It's safe to change this as [`http`](https://github.com/dart-lang/http/blob/1e42ffa181b263f7790f276a5465832bff7ce615/lib/src/browser_client.dart#L57) also does this and has even wider adoption rates.
