### PR TITLE
Export barrel dependencies for conditional imports

### DIFF
--- a/dio/lib/barrels.dart
+++ b/dio/lib/barrels.dart
@@ -1,0 +1,14 @@
+export 'src/adapter.dart';
+export 'src/cancel_token.dart';
+export 'src/dio.dart';
+export 'src/dio_error.dart';
+export 'src/dio_mixin.dart' hide InterceptorState, InterceptorResultType;
+export 'src/form_data.dart';
+export 'src/headers.dart';
+export 'src/interceptors/log.dart';
+export 'src/multipart_file.dart';
+export 'src/options.dart';
+export 'src/parameter.dart';
+export 'src/redirect_record.dart';
+export 'src/response.dart';
+export 'src/transformer.dart';

--- a/dio/lib/browser_imp.dart
+++ b/dio/lib/browser_imp.dart
@@ -1,1 +1,3 @@
 export 'src/entry/dio_for_browser.dart' show DioForBrowser;
+
+export 'barrels.dart';

--- a/dio/lib/dio.dart
+++ b/dio/lib/dio.dart
@@ -5,17 +5,4 @@
 /// A open source project authorized by [https://flutterchina.club](https://flutterchina.club).
 library dio;
 
-export 'src/adapter.dart';
-export 'src/cancel_token.dart';
-export 'src/dio.dart';
-export 'src/dio_error.dart';
-export 'src/dio_mixin.dart' hide InterceptorState, InterceptorResultType;
-export 'src/form_data.dart';
-export 'src/headers.dart';
-export 'src/interceptors/log.dart';
-export 'src/multipart_file.dart';
-export 'src/options.dart';
-export 'src/parameter.dart';
-export 'src/redirect_record.dart';
-export 'src/response.dart';
-export 'src/transformer.dart';
+export 'barrels.dart';

--- a/dio/lib/native_imp.dart
+++ b/dio/lib/native_imp.dart
@@ -1,1 +1,3 @@
 export 'src/entry/dio_for_native.dart' show DioForNative;
+
+export 'barrels.dart';


### PR DESCRIPTION
# Problem Statement
I have a `Flutter Web` application that needs to have *Cookie* in headers.
To enable sending `Cookie` in *request headers* we need to add the following code to our Dio object:
```dart
// conditional import to support BrowserHttpClientAdapter for Web.
import 'package:dio/dio.dart'
    if (dart.library.io) 'package:dio/native_imp.dart'
    if (dart.library.html) 'package:dio/browser_imp.dart';

_dio.options = BaseOptions(
      receiveTimeout: receiveTimeout,
      connectTimeout: connectTimeout,
      sendTimeout: sendTimeout,
      extra: kIsWeb ? {'withCredentials': true} : null, // allow sending Cookie in header
 );
```

When `running` or `building` for Web we have these compile errors:
```bat
lib/data/repository.dart:236:8: Error: Type 'Dio' not found.
    late Dio _dio;^^^^
lib/data/repository.dart:246:20: Error: The method 'BaseOptions' isn't defined for the class '_RepositoryImpl'.
 - '_RepositoryImpl' is from 'package:zireh/data/repository.dart' ('lib/data/repository.dart').
Try correcting the name to the name of an existing method, or defining a method named 'BaseOptions'.
    _dio.options = BaseOptions(^^^^

Failed to compile application.
```

# What this pull request solves
This pull request is exporting dependencies for both `native` and `web` implementations of *Dio*.