### PR TITLE
Proposal: Remove send and receive timeouts

### DIFF
--- a/dio/lib/src/entry/dio_for_native.dart
+++ b/dio/lib/src/entry/dio_for_native.dart
@@ -216,22 +216,6 @@ class DioForNative with DioMixin implements Dio {
       await _closeAndDelete();
     });
 
-    final timeout = response.requestOptions.receiveTimeout;
-    if (timeout != null) {
-      future = future.timeout(timeout).catchError((Object err) async {
-        await subscription.cancel();
-        await _closeAndDelete();
-        if (err is TimeoutException) {
-          throw DioError(
-            requestOptions: response.requestOptions,
-            error: 'Receiving data timeout[$timeout]',
-            type: DioErrorType.receiveTimeout,
-          );
-        } else {
-          throw err;
-        }
-      });
-    }
     return DioMixin.listenCancelForAsyncTask(cancelToken, future);
   }
 

--- a/dio/lib/src/interceptors/log.dart
+++ b/dio/lib/src/interceptors/log.dart
@@ -59,9 +59,7 @@ class LogInterceptor extends Interceptor {
       _printKV('method', options.method);
       _printKV('responseType', options.responseType.toString());
       _printKV('followRedirects', options.followRedirects);
-      _printKV('connectTimeout', options.connectTimeout);
-      _printKV('sendTimeout', options.sendTimeout);
-      _printKV('receiveTimeout', options.receiveTimeout);
+      _printKV('connectTimeout', options.connectionTimeout);
       _printKV(
           'receiveDataWhenStatusError', options.receiveDataWhenStatusError);
       _printKV('extra', options.extra);

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -82,9 +82,7 @@ typedef RequestEncoder = List<int> Function(
 class BaseOptions extends _RequestConfig with OptionsMixin {
   BaseOptions({
     String? method,
-    Duration? connectTimeout,
-    Duration? receiveTimeout,
-    Duration? sendTimeout,
+    Duration? connectionTimeout,
     String baseUrl = '',
     Map<String, Object?>? queryParameters,
     Map<String, Object?>? extra,
@@ -99,11 +97,9 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
     this.setRequestContentTypeWhenNoPayload = false,
-  })  : assert(connectTimeout == null || !connectTimeout.isNegative),
+  })  : assert(connectionTimeout == null || !connectionTimeout.isNegative),
         super(
           method: method,
-          receiveTimeout: receiveTimeout,
-          sendTimeout: sendTimeout,
           extra: extra,
           headers: headers,
           responseType: responseType,
@@ -118,7 +114,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
         ) {
     this.queryParameters = queryParameters ?? {};
     this.baseUrl = baseUrl;
-    this.connectTimeout = connectTimeout;
+    this.connectionTimeout = connectionTimeout;
   }
 
   /// Create a Option from current instance with merging attributes.
@@ -127,7 +123,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     String? baseUrl,
     Map<String, Object?>? queryParameters,
     String? path,
-    Duration? connectTimeout,
+    Duration? connectionTimeout,
     Duration? receiveTimeout,
     Duration? sendTimeout,
     Map<String, Object?>? extra,
@@ -147,9 +143,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
       method: method ?? this.method,
       baseUrl: baseUrl ?? this.baseUrl,
       queryParameters: queryParameters ?? this.queryParameters,
-      connectTimeout: connectTimeout ?? this.connectTimeout,
-      receiveTimeout: receiveTimeout ?? this.receiveTimeout,
-      sendTimeout: sendTimeout ?? this.sendTimeout,
+      connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       extra: extra ?? Map.from(this.extra),
       headers: headers ?? Map.from(this.headers),
       responseType: responseType ?? this.responseType,
@@ -194,26 +188,24 @@ mixin OptionsMixin {
   late Map<String, Object?> queryParameters;
 
   /// Timeout in milliseconds for opening url.
-  /// [Dio] will throw the [DioError] with [DioErrorType.connectTimeout] type
+  /// [Dio] will throw the [DioError] with [DioErrorType.connectionTimeout] type
   ///  when time out.
-  Duration? get connectTimeout => _connectTimeout;
+  Duration? get connectionTimeout => _connectionTimeout;
 
-  set connectTimeout(Duration? value) {
+  set connectionTimeout(Duration? value) {
     if (value != null && value.isNegative) {
-      throw StateError("connectTimeout should be positive");
+      throw StateError("connectionTimeout should be positive");
     }
-    _connectTimeout = value;
+    _connectionTimeout = value;
   }
 
-  Duration? _connectTimeout;
+  Duration? _connectionTimeout;
 }
 
 /// Every request can pass an [Options] object which will be merged with [Dio.options]
 class Options {
   Options({
     this.method,
-    Duration? sendTimeout,
-    Duration? receiveTimeout,
     this.extra,
     this.headers,
     this.responseType,
@@ -225,16 +217,11 @@ class Options {
     this.requestEncoder,
     this.responseDecoder,
     this.listFormat,
-  })  : assert(receiveTimeout == null || !receiveTimeout.isNegative),
-        _receiveTimeout = receiveTimeout,
-        assert(sendTimeout == null || !sendTimeout.isNegative),
-        _sendTimeout = sendTimeout;
+  });
 
   /// Create a Option from current instance with merging attributes.
   Options copyWith({
     String? method,
-    Duration? sendTimeout,
-    Duration? receiveTimeout,
     Map<String, Object?>? extra,
     Map<String, Object?>? headers,
     ResponseType? responseType,
@@ -268,8 +255,6 @@ class Options {
 
     return Options(
       method: method ?? this.method,
-      sendTimeout: sendTimeout ?? this.sendTimeout,
-      receiveTimeout: receiveTimeout ?? this.receiveTimeout,
       extra: extra ?? _extra,
       headers: headers ?? _headers,
       responseType: responseType ?? this.responseType,
@@ -321,9 +306,7 @@ class Options {
       baseUrl: baseOpt.baseUrl,
       path: path,
       data: data,
-      connectTimeout: baseOpt.connectTimeout,
-      sendTimeout: sendTimeout ?? baseOpt.sendTimeout,
-      receiveTimeout: receiveTimeout ?? baseOpt.receiveTimeout,
+      connectionTimeout: baseOpt.connectionTimeout,
       responseType: responseType ?? baseOpt.responseType,
       validateStatus: validateStatus ?? baseOpt.validateStatus,
       receiveDataWhenStatusError:
@@ -355,37 +338,6 @@ class Options {
   /// The key of Header Map is case-insensitive, eg: content-type and Content-Type are
   /// regard as the same key.
   Map<String, Object?>? headers;
-
-  /// Timeout in milliseconds for sending data.
-  /// [Dio] will throw the [DioError] with [DioErrorType.sendTimeout] type
-  ///  when time out.
-  Duration? get sendTimeout => _sendTimeout;
-
-  set sendTimeout(Duration? value) {
-    if (value != null && value.isNegative) {
-      throw StateError("sendTimeout should be positive");
-    }
-    _sendTimeout = value;
-  }
-
-  Duration? _sendTimeout;
-
-  ///  Timeout in milliseconds for receiving data.
-  ///
-  ///  Note: [receiveTimeout]  represents a timeout during data transfer! That is to say the
-  ///  client has connected to the server, and the server starts to send data to the client.
-  ///
-  /// `null` meanings no timeout limit.
-  Duration? get receiveTimeout => _receiveTimeout;
-
-  set receiveTimeout(Duration? value) {
-    if (value != null && value.isNegative) {
-      throw StateError('receiveTimeout should be positive');
-    }
-    _receiveTimeout = value;
-  }
-
-  Duration? _receiveTimeout;
 
   /// The request Content-Type. The default value is [ContentType.json].
   /// If you want to encode request body with 'application/x-www-form-urlencoded',
@@ -449,9 +401,7 @@ class Options {
 class RequestOptions extends _RequestConfig with OptionsMixin {
   RequestOptions({
     String? method,
-    Duration? sendTimeout,
-    Duration? receiveTimeout,
-    Duration? connectTimeout,
+    Duration? connectionTimeout,
     this.data,
     required this.path,
     Map<String, Object?>? queryParameters,
@@ -471,11 +421,9 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
     bool? setRequestContentTypeWhenNoPayload,
-  })  : assert(connectTimeout == null || !connectTimeout.isNegative),
+  })  : assert(connectionTimeout == null || !connectionTimeout.isNegative),
         super(
           method: method,
-          sendTimeout: sendTimeout,
-          receiveTimeout: receiveTimeout,
           extra: extra,
           headers: headers,
           responseType: responseType,
@@ -490,15 +438,13 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
         ) {
     this.queryParameters = queryParameters ?? {};
     this.baseUrl = baseUrl ?? '';
-    this.connectTimeout = connectTimeout;
+    this.connectionTimeout = connectionTimeout;
   }
 
   /// Create a Option from current instance with merging attributes.
   RequestOptions copyWith({
     String? method,
-    Duration? sendTimeout,
-    Duration? receiveTimeout,
-    Duration? connectTimeout,
+    Duration? connectionTimeout,
     String? data,
     String? path,
     Map<String, Object?>? queryParameters,
@@ -528,12 +474,14 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
       !(contentType != null && contentTypeInHeader),
       'You cannot set both contentType param and a content-type header',
     );
+    assert(
+      connectionTimeout == null || connectionTimeout.isNegative,
+      'connectionTimeout must be positive',
+    );
 
     var ro = RequestOptions(
       method: method ?? this.method,
-      sendTimeout: sendTimeout ?? this.sendTimeout,
-      receiveTimeout: receiveTimeout ?? this.receiveTimeout,
-      connectTimeout: connectTimeout ?? this.connectTimeout,
+      connectionTimeout: connectionTimeout ?? this.connectionTimeout,
       data: data ?? this.data,
       path: path ?? this.path,
       baseUrl: baseUrl ?? this.baseUrl,
@@ -605,8 +553,6 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
 /// The [_RequestConfig] class describes the http request information and configuration.
 class _RequestConfig {
   _RequestConfig({
-    Duration? receiveTimeout,
-    Duration? sendTimeout,
     String? method,
     Map<String, Object?>? extra,
     Map<String, Object?>? headers,
@@ -619,10 +565,7 @@ class _RequestConfig {
     ResponseType? responseType,
     this.requestEncoder,
     this.responseDecoder,
-  })  : assert(receiveTimeout == null || !receiveTimeout.isNegative),
-        _receiveTimeout = receiveTimeout,
-        assert(sendTimeout == null || !sendTimeout.isNegative),
-        _sendTimeout = sendTimeout {
+  }) {
     this.headers = headers;
 
     var contentTypeInHeader =
@@ -668,39 +611,6 @@ class _RequestConfig {
       _headers[Headers.contentTypeHeader] = _defaultContentType;
     }
   }
-
-  /// Timeout in milliseconds for sending data.
-  /// [Dio] will throw the [DioError] with [DioErrorType.sendTimeout] type
-  ///  when time out.
-  ///
-  /// `null` meanings no timeout limit.
-  Duration? get sendTimeout => _sendTimeout;
-
-  set sendTimeout(Duration? value) {
-    if (value != null && value.isNegative) {
-      throw StateError("sendTimeout should be positive");
-    }
-    _sendTimeout = value;
-  }
-
-  Duration? _sendTimeout;
-
-  ///  Timeout in milliseconds for receiving data.
-  ///
-  ///  Note: [receiveTimeout]  represents a timeout during data transfer! That is to say the
-  ///  client has connected to the server, and the server starts to send data to the client.
-  ///
-  /// `null` meanings no timeout limit.
-  Duration? get receiveTimeout => _receiveTimeout;
-
-  set receiveTimeout(Duration? value) {
-    if (value != null && value.isNegative) {
-      throw StateError("reveiveTimeout should be positive");
-    }
-    _receiveTimeout = value;
-  }
-
-  Duration? _receiveTimeout;
 
   /// The request Content-Type. The default value is [ContentType.json].
   /// If you want to encode request body with 'application/x-www-form-urlencoded',

--- a/dio/test/download_test.dart
+++ b/dio/test/download_test.dart
@@ -61,20 +61,6 @@ void main() {
     assert(r.data == null);
   });
 
-  test('#test download timeout', () async {
-    const savePath = 'test/_download_test.md';
-    var dio = Dio(BaseOptions(
-      receiveTimeout: Duration(milliseconds: 1),
-      baseUrl: serverUrl.toString(),
-    ));
-    expect(
-        dio
-            .download('/download', savePath)
-            .catchError((e) => throw (e as DioError).type),
-        throwsA(DioErrorType.receiveTimeout));
-    //print(r);
-  });
-
   test('#test download cancellation', () async {
     const savePath = 'test/_download_test.md';
     var cancelToken = CancelToken();

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -12,9 +12,7 @@ void main() {
     var map = {'a': '5'};
     var mapOverride = {'b': '6'};
     var baseOptions = BaseOptions(
-      connectTimeout: Duration(seconds: 2),
-      receiveTimeout: Duration(seconds: 2),
-      sendTimeout: Duration(seconds: 2),
+      connectionTimeout: Duration(seconds: 2),
       baseUrl: 'http://localhost',
       queryParameters: map,
       extra: map,
@@ -32,8 +30,7 @@ void main() {
       contentType: 'text/html',
     );
     assert(opt1.method == 'post');
-    assert(opt1.receiveTimeout == Duration(seconds: 3));
-    assert(opt1.connectTimeout == Duration(seconds: 2));
+    assert(opt1.connectionTimeout == Duration(seconds: 2));
     assert(opt1.followRedirects == false);
     assert(opt1.baseUrl == 'https://flutterchina.club');
     assert(opt1.headers['b'] == '6');
@@ -43,8 +40,6 @@ void main() {
 
     var opt2 = Options(
       method: 'get',
-      receiveTimeout: Duration(seconds: 2),
-      sendTimeout: Duration(seconds: 2),
       extra: map,
       headers: map,
       contentType: 'application/json',
@@ -53,15 +48,12 @@ void main() {
 
     var opt3 = opt2.copyWith(
       method: 'post',
-      receiveTimeout: Duration(seconds: 3),
-      sendTimeout: Duration(seconds: 3),
       extra: mapOverride,
       headers: mapOverride,
       contentType: 'text/html',
     );
 
     assert(opt3.method == 'post');
-    assert(opt3.receiveTimeout == Duration(seconds: 3));
     assert(opt3.followRedirects == false);
     assert(opt3.headers!['b'] == '6');
     assert(opt3.extra!['b'] == '6');
@@ -69,13 +61,10 @@ void main() {
 
     var opt4 = RequestOptions(
       path: '/xxx',
-      sendTimeout: Duration(seconds: 2),
       followRedirects: false,
     );
     var opt5 = opt4.copyWith(
       method: 'post',
-      receiveTimeout: Duration(seconds: 3),
-      sendTimeout: Duration(seconds: 3),
       extra: mapOverride,
       headers: mapOverride,
       data: 'xx=5',
@@ -83,7 +72,6 @@ void main() {
       contentType: 'text/html',
     );
     assert(opt5.method == 'post');
-    assert(opt5.receiveTimeout == Duration(seconds: 3));
     assert(opt5.followRedirects == false);
     assert(opt5.contentType == 'text/html');
     assert(opt5.headers['b'] == '6');

--- a/dio/test/readtimeout_test.dart
+++ b/dio/test/readtimeout_test.dart
@@ -53,36 +53,13 @@ void main() {
   tearDown(stopServer);
 
   test(
-      '#read_timeout - catch DioError when receiveTimeout < $_sleepDurationAfterConnectionEstablished',
-      () async {
-    var dio = Dio();
-
-    dio.options
-      ..baseUrl = serverUrl.toString()
-      ..receiveTimeout =
-          _sleepDurationAfterConnectionEstablished - Duration(seconds: 1);
-
-    DioError error;
-
-    try {
-      await dio.get('/');
-      fail('did not throw');
-    } on DioError catch (e) {
-      error = e;
-    }
-
-    expect(error, isNotNull);
-    expect(error.type == DioErrorType.receiveTimeout, isTrue);
-  });
-
-  test(
       '#read_timeout - no DioError when receiveTimeout > $_sleepDurationAfterConnectionEstablished',
       () async {
     var dio = Dio();
 
     dio.options
       ..baseUrl = serverUrl.toString()
-      ..connectTimeout =
+      ..connectionTimeout =
           _sleepDurationAfterConnectionEstablished + Duration(seconds: 1);
 
     DioError? error;

--- a/dio/test/request_test.dart
+++ b/dio/test/request_test.dart
@@ -19,8 +19,7 @@ void main() {
       dio = Dio();
       dio.options
         ..baseUrl = serverUrl.toString()
-        ..connectTimeout = Duration(seconds: 1)
-        ..receiveTimeout = Duration(seconds: 5)
+        ..connectionTimeout = Duration(seconds: 1)
         ..headers = {'User-Agent': 'dartisan'};
       dio.interceptors.add(LogInterceptor(
         responseBody: true,

--- a/example/lib/dio.dart
+++ b/example/lib/dio.dart
@@ -5,8 +5,6 @@ void main() async {
   var dio = Dio();
   dio.options
     ..baseUrl = 'http://httpbin.org/'
-    ..connectTimeout = Duration(seconds: 5)
-    ..receiveTimeout = Duration(seconds: 5)
     ..validateStatus = (int? status) {
       return status != null && status > 0;
     }

--- a/example/lib/download.dart
+++ b/example/lib/download.dart
@@ -42,7 +42,6 @@ Future download2(Dio dio, String url, String savePath) async {
       options: Options(
         responseType: ResponseType.bytes,
         followRedirects: false,
-        receiveTimeout: Duration.zero,
       ),
     );
     print(response.headers);

--- a/example/lib/options.dart
+++ b/example/lib/options.dart
@@ -4,8 +4,6 @@ import 'package:dio/dio.dart';
 void main() async {
   var dio = Dio(BaseOptions(
     baseUrl: 'http://httpbin.org/',
-    connectTimeout: Duration(seconds: 5),
-    receiveTimeout: Duration(seconds: 10),
     // 5s
     headers: {
       HttpHeaders.userAgentHeader: 'dio',

--- a/example/lib/post_stream_and_bytes.dart
+++ b/example/lib/post_stream_and_bytes.dart
@@ -6,7 +6,6 @@ import 'package:dio/dio.dart';
 
 void main() async {
   var dio = Dio(BaseOptions(
-    connectTimeout: Duration(seconds: 5),
     baseUrl: 'http://httpbin.org/',
   ));
 

--- a/example/lib/request_interceptors.dart
+++ b/example/lib/request_interceptors.dart
@@ -3,7 +3,6 @@ import 'package:dio/dio.dart';
 void main() async {
   var dio = Dio();
   dio.options.baseUrl = 'http://httpbin.org/';
-  dio.options.connectTimeout = Duration(seconds: 5);
   dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) {
     switch (options.path) {
       case '/fakepath1':

--- a/example_flutter_app/lib/routes/request.dart
+++ b/example_flutter_app/lib/routes/request.dart
@@ -40,9 +40,7 @@ class _RequestRouteState extends State<RequestRoute> {
                   .post(
                 "http://httpbin.org/post",
                 data: formData,
-                options: Options(
-                    sendTimeout: Duration(seconds: 2),
-                    receiveTimeout: Duration(seconds: 0)),
+                options: Options(),
                 onSendProgress: (a, b) => print('send ${a / b}'),
                 onReceiveProgress: (a, b) => print('received ${a / b}'),
               )

--- a/plugins/http2_adapter/lib/src/connection_manager_imp.dart
+++ b/plugins/http2_adapter/lib/src/connection_manager_imp.dart
@@ -71,7 +71,7 @@ class _ConnectionManager implements ConnectionManager {
       socket = await SecureSocket.connect(
         uri.host,
         uri.port,
-        timeout: options.connectTimeout,
+        timeout: options.connectionTimeout,
         context: clientConfig.context,
         onBadCertificate: clientConfig.onBadCertificate,
         supportedProtocols: ['h2'],
@@ -81,7 +81,7 @@ class _ConnectionManager implements ConnectionManager {
         if (e.message.contains('timed out')) {
           throw DioError(
             requestOptions: options,
-            error: 'Connecting timed out [${options.connectTimeout}]',
+            error: 'Connecting timed out [${options.connectionTimeout}]',
             type: DioErrorType.connectTimeout,
           );
         }


### PR DESCRIPTION
This PR removes send and receive timeouts. It's meant as a basis for a discussion.

As you can see, the current implementation just adds send and receive timeouts itself. It's not a concept of the underlying APIs (xhr and HttpClient). The Http2 adapter doesn't support it at all.

Removing these timeouts could lead to a pretty nice amount of reduced complexity and code.