### PR TITLE
Fix BrowserHttpClientAdapter canceled hangs

### DIFF
--- a/.github/workflows/dio.yml
+++ b/.github/workflows/dio.yml
@@ -45,6 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         sdk: [ stable, beta, 2.12.1 ]
+        platform: [ vm, chrome ]
     defaults:
       run:
         working-directory: dio
@@ -54,13 +55,12 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: pub get
-      - run: dart test --chain-stack-traces --platform=vm
-      - run: dart test --chain-stack-traces --platform=chrome
+      - run: dart test --chain-stack-traces --platform=${{ matrix.platform }}
       - name: Upload test report
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-results-${{ matrix.sdk }}
+          name: test-results-${{ matrix.sdk }}-${{ matrix.platform }}
           path: dio/build/reports/test-results.json
 
   publish-dry-run:

--- a/.github/workflows/dio.yml
+++ b/.github/workflows/dio.yml
@@ -54,7 +54,8 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: pub get
-      - run: dart test --chain-stack-traces
+      - run: dart test --chain-stack-traces --platform=vm
+      - run: dart test --chain-stack-traces --platform=chrome
       - name: Upload test report
         uses: actions/upload-artifact@v2
         if: always() && matrix.sdk == 'stable'

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
 - Only delete file if it exists when downloading.
+- Fix `BrowserHttpClientAdapter` canceled hangs
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -148,12 +148,19 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       );
     });
 
-    cancelFuture?.then((_) {
+    cancelFuture?.then((err) {
       if (xhr.readyState < 4 && xhr.readyState > 0) {
         try {
           xhr.abort();
         } catch (e) {
           // ignore
+        }
+
+        // xhr.onError will not triggered when xhr.abort() called.
+        // so need to manual throw the cancel error to avoid Future hang ups.
+        // or added xhr.onAbort like axios did https://github.com/axios/axios/blob/master/lib/adapters/xhr.js#L102-L111
+        if (!completer.isCompleted) {
+          completer.completeError(err);
         }
       }
     });

--- a/dio/test/basic_test.dart
+++ b/dio/test/basic_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-@TestOn('vm')
 import 'dart:async';
 import 'dart:io';
 
@@ -46,7 +45,7 @@ void main() {
       Dio().get('http://http.invalid'),
       throwsA((e) => e is DioError && e.error is SocketException),
     );
-  });
+  }, testOn: "vm");
 
   test('#cancellation', () async {
     var dio = Dio();

--- a/dio/test/readtimeout_test.dart
+++ b/dio/test/readtimeout_test.dart
@@ -1,5 +1,7 @@
+@TestOn("vm")
 import 'dart:async';
 import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 

--- a/dio/test/upload_stream_test.dart
+++ b/dio/test/upload_stream_test.dart
@@ -39,7 +39,7 @@ void main() {
     );
     var img = base64Encode(f.readAsBytesSync());
     expect(r.data['data'], 'data:application/octet-stream;base64,' + img);
-  });
+  }, testOn: "vm");
 
   test('file stream<Uint8List>', () async {
     var f = File('../dio/test/test.jpg');
@@ -55,5 +55,5 @@ void main() {
     );
     var img = base64Encode(f.readAsBytesSync());
     expect(r.data['data'], 'data:application/octet-stream;base64,' + img);
-  });
+  }, testOn: "vm");
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

could check case https://github.com/morlay/roundtripper/runs/4862938300?check_suite_focus=true

When using `BrowserHttpClientAdapter` cancel hangs until timeout. `DefaultHttpClientAdapter` work well.
```
00:39 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:40 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:41 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:42 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:43 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:44 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:45 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:46 +4: test/basic_test.dart: cancel                                                                                                                                                                 
00:46 +4 -1: test/basic_test.dart: cancel [E]                                                                                                                                                          
  TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
  package:test_api                                 Invoker._handleError.<fn>
  org-dartlang-sdk:///lib/async/zone.dart 1420:46  StaticClosure._rootRun
  org-dartlang-sdk:///lib/async/zone.dart 1327:34  _CustomZone.run
  package:test_api                                 Invoker.heartbeat.<fn>.<fn>
  org-dartlang-sdk:///lib/async/zone.dart 1428:12  StaticClosure._rootRun
  org-dartlang-sdk:///lib/async/zone.dart 1327:34  _CustomZone.run
```

When patch the code in this PR, everything fine.
