### PR TITLE
fix: Only delete file when it exists

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
 - `ResponseBody.statusCode` is now non-nullable
+- Only delete file if it exists when downloading.
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/lib/src/entry/dio_for_native.dart
+++ b/dio/lib/src/entry/dio_for_native.dart
@@ -155,7 +155,9 @@ class DioForNative with DioMixin implements Dio {
         closed = true;
         await asyncWrite;
         await raf.close();
-        if (deleteOnError) await file.delete();
+        if (deleteOnError && file.existsSync()) {
+          await file.delete();
+        }
       }
     }
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: N/A

### Pull Request Description

Before we delete the downloading file, we should determine whether it exists.