### PR TITLE
Revert "It's safe for status code to be non-null"

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
-- `ResponseBody.statusCode` is now non-nullable
 - Only delete file if it exists when downloading.
 
 # 4.0.5-beta1

--- a/dio/lib/src/adapter.dart
+++ b/dio/lib/src/adapter.dart
@@ -61,10 +61,10 @@ class ResponseBody {
   Stream<Uint8List> stream;
 
   /// the response headers
-  Map<String, List<String>> headers;
+  late Map<String, List<String>> headers;
 
   /// Http status code
-  int statusCode;
+  int? statusCode;
 
   /// Returns the reason phrase associated with the status code.
   /// The reason phrase must be set before the body is written

--- a/dio/lib/src/adapters/browser_adapter.dart
+++ b/dio/lib/src/adapters/browser_adapter.dart
@@ -53,7 +53,7 @@ class BrowserHttpClientAdapter implements HttpClientAdapter {
       completer.complete(
         ResponseBody.fromBytes(
           body,
-          xhr.status!,
+          xhr.status,
           headers: xhr.responseHeaders.map((k, v) => MapEntry(k, v.split(','))),
           statusMessage: xhr.statusText,
           isRedirect: xhr.status == 302 || xhr.status == 301,


### PR DESCRIPTION
It was a breaking change, so we have to revert it.

cc @kuhnroyal 