### PR TITLE
Expect different keys for list of maps in multiCompatible FormData

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,6 +2,29 @@
 - require Dart `2.12.1` which fixes exception handling for secure socket connections (https://github.com/dart-lang/sdk/issues/45214)  
 - Only delete file if it exists when downloading.
 - Fix `BrowserHttpClientAdapter` canceled hangs
+- Fix encoding map using ListFormat.multiCompatible when formatting list of maps.
+  ```
+    FormData.fromMap({"nested": [
+        {"id": "idA", "name": "nameA"},
+        {"id": "idB"},
+      ]}, ListFormat.multiCompatible)
+  ```
+  previously:
+  ```
+    #=>
+    nested[0][id]=idA
+    nested[0][name]=nameA
+    nested[1][id]=idB
+  ```
+  current:
+  ```
+    #=>
+    nested[][id]=idA
+    nested[][name]=nameA
+    nested[][id]=idB
+  ```
+
+
 
 # 4.0.5-beta1
 - [Web] support send/receive progress in web platform

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -60,8 +60,7 @@ String encodeMap(
         for (var i = 0; i < sub.length; i++) {
           final isListType = sub[i] is List || sub[i] is ListParam;
           if (listFormat == ListFormat.multi) {
-            final isCollection =
-                sub[i] is Map || isListType;
+            final isCollection = sub[i] is Map || isListType;
             urlEncode(
               sub[i],
               '$path${isCollection ? leftBracket + '$i' + rightBracket : ''}',

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -58,9 +58,9 @@ String encodeMap(
     if (sub is List) {
       if (format == ListFormat.multi || format == ListFormat.multiCompatible) {
         for (var i = 0; i < sub.length; i++) {
-          final isCollection =
-              sub[i] is Map || sub[i] is List || sub[i] is ListParam;
           if (listFormat == ListFormat.multi) {
+            final isCollection =
+                sub[i] is Map || sub[i] is List || sub[i] is ListParam;
             urlEncode(
               sub[i],
               '$path${isCollection ? leftBracket + '$i' + rightBracket : ''}',
@@ -69,7 +69,7 @@ String encodeMap(
             // Forward compatibility
             urlEncode(
               sub[i],
-              '$path$leftBracket${isCollection ? i : ''}$rightBracket',
+              '$path$leftBracket$rightBracket',
             );
           }
         }

--- a/dio/lib/src/utils.dart
+++ b/dio/lib/src/utils.dart
@@ -58,9 +58,10 @@ String encodeMap(
     if (sub is List) {
       if (format == ListFormat.multi || format == ListFormat.multiCompatible) {
         for (var i = 0; i < sub.length; i++) {
+          final isListType = sub[i] is List || sub[i] is ListParam;
           if (listFormat == ListFormat.multi) {
             final isCollection =
-                sub[i] is Map || sub[i] is List || sub[i] is ListParam;
+                sub[i] is Map || isListType;
             urlEncode(
               sub[i],
               '$path${isCollection ? leftBracket + '$i' + rightBracket : ''}',
@@ -69,7 +70,7 @@ String encodeMap(
             // Forward compatibility
             urlEncode(
               sub[i],
-              '$path$leftBracket$rightBracket',
+              '$path$leftBracket${isListType ? i : ''}$rightBracket',
             );
           }
         }

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -79,12 +79,12 @@ void main() async {
         {"id": "idA", "name": "nameA"},
         {"id": "idB"},
         {"id": "idC", "name": "nameC"}
-        ],
+      ],
       "list": [
         ["a", "b", "c"],
         ["d", "e"]
       ]
-        };
+    };
 
     final formData = FormData.fromMap(map, ListFormat.multiCompatible);
     final expected = [

--- a/dio/test/formdata_test.dart
+++ b/dio/test/formdata_test.dart
@@ -71,4 +71,37 @@ void main() async {
     ));
     assert(fmStr.length == fm1.length);
   });
+
+  test("formData multiCompatible", () {
+    final map = {
+      "unnested": ["a", "b", "c"],
+      "nested": [
+        {"id": "idA", "name": "nameA"},
+        {"id": "idB"},
+        {"id": "idC", "name": "nameC"}
+        ],
+      "list": [
+        ["a", "b", "c"],
+        ["d", "e"]
+      ]
+        };
+
+    final formData = FormData.fromMap(map, ListFormat.multiCompatible);
+    final expected = [
+      MapEntry("unnested[]", "a"),
+      MapEntry("unnested[]", "b"),
+      MapEntry("unnested[]", "c"),
+      MapEntry("nested[][id]", "idA"),
+      MapEntry("nested[][name]", "nameA"),
+      MapEntry("nested[][id]", "idB"),
+      MapEntry("nested[][id]", "idC"),
+      MapEntry("nested[][name]", "nameC"),
+      MapEntry("list[0][]", "a"),
+      MapEntry("list[0][]", "b"),
+      MapEntry("list[0][]", "c"),
+      MapEntry("list[1][]", "d"),
+      MapEntry("list[1][]", "e")
+    ];
+    assert(formData.fields.toString() == expected.toString());
+  });
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

I was having an issue with posting lists of maps using formdata to my rails backend using the Listformat.multiCompatible.
My guess is that during key generation we do not wish to add [i] if the list entry value is a Map. See test-code added for my expectation.

I have currently not altered the expected outcome of nested lists as I am uncertain how they should be represented.

The frame of reference from my expectations come from rails documentation and working with forms in rails
https://guides.rubyonrails.org/v6.1/form_helpers.html#combining-them

If anyone has any more insight or pointers as to where I can find some specs I'm happy to learn more :) 
