### PR TITLE
Fix requestOption copyWith's argument type for data

### DIFF
--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -467,7 +467,7 @@ class RequestOptions extends _RequestConfig with OptionsMixin {
     int? sendTimeout,
     int? receiveTimeout,
     int? connectTimeout,
-    String? data,
+    dynamic data,
     String? path,
     Map<String, dynamic>? queryParameters,
     String? baseUrl,


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: https://github.com/flutterchina/dio/issues/1420

### Pull Request Description

I've changed `data` arg type to `dynamic` in the `.copyWith` method.

