### PR TITLE
add badssl to exception_test.dart

### DIFF
--- a/dio/test/exception_test.dart
+++ b/dio/test/exception_test.dart
@@ -1,5 +1,7 @@
+import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
+import 'package:dio/adapter.dart';
 
 void main() {
   test('catch DioError', () async {
@@ -29,4 +31,32 @@ void main() {
     expect(error, isNotNull);
     expect(error is Exception, isTrue);
   });
+
+  test('catch sslerror: hostname mismatch', () async {
+    dynamic error;
+
+    try {
+      await Dio().get('https://wrong.host.badssl.com/');
+      fail('did not throw');
+    } on DioError catch (e) {
+      error = e;
+    }
+    expect(error, isNotNull);
+    expect(error is Exception, isTrue);
+  });
+
+  test('allow badssl', () async {
+    var dio = Dio();
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (HttpClient client) {
+      client.badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+    };
+    var response = await dio.get('https://wrong.host.badssl.com/');
+    expect(response.statusCode, 200);
+    response = await dio.get('https://expired.badssl.com/');
+    expect(response.statusCode, 200);
+    response = await dio.get('https://self-signed.badssl.com/');
+    expect(response.statusCode, 200);
+  }, testOn: "!browser");
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Additional tests to ensure `badCertificateCallback`. It can also serve as an example.
I hope it's in the right place.