### PR TITLE
Correct JSON MIME Type detection

### DIFF
--- a/dio/test/mimetype_test.dart
+++ b/dio/test/mimetype_test.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('JSON MimeType "application/json" ', () {
+    expect(Transformer.isJsonMimeType("application/json"), isTrue);
+  });
+
+  test('JSON MimeType "text/json" ', () {
+    expect(Transformer.isJsonMimeType("text/json"), isTrue);
+  });
+
+  test('JSON MimeType "application/vnd.example.com+json" ', () {
+    expect(Transformer.isJsonMimeType("text/json"), isTrue);
+  });
+}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description
The current JSON MIME Type check doesn't include the "+json" subtype specification.
The implementation provided in this PR follows [this](https://mimesniff.spec.whatwg.org/#json-mime-type) specification.