### PR TITLE
fix: abort request when timeout occurs

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -61,6 +61,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       }
       rethrow;
     } on TimeoutException {
+      request.abort();
       _throwConnectingTimeout();
     }
 
@@ -76,6 +77,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
       try {
         await future;
       } on TimeoutException {
+        request.abort();
         throw DioError(
           requestOptions: options,
           error: 'Sending timeout[${options.sendTimeout}ms]',
@@ -116,7 +118,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
             ),
           );
           //todo: to verify
-          responseStream.detachSocket().then((socket) => socket.close());
+          responseStream.detachSocket().then((socket) => socket.destroy());
         } else {
           sink.add(Uint8List.fromList(data));
         }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

- https://github.com/flutterchina/dio/issues/1229
- https://github.com/flutterchina/dio/pull/1387


### Pull Request Description

`browser_adapter` abort request when timeout occurs.

https://github.com/flutterchina/dio/blob/6d04ec95d951bdecd19a2939d94de217d2d1ff7d/dio/lib/src/adapters/browser_adapter.dart#L78
https://github.com/flutterchina/dio/blob/6d04ec95d951bdecd19a2939d94de217d2d1ff7d/dio/lib/src/adapters/browser_adapter.dart#L102
https://github.com/flutterchina/dio/blob/6d04ec95d951bdecd19a2939d94de217d2d1ff7d/dio/lib/src/adapters/browser_adapter.dart#L128


`io_adapter` detach socket when `receiveTimeout` is occurs.
https://github.com/flutterchina/dio/blob/6d04ec95d951bdecd19a2939d94de217d2d1ff7d/dio/lib/src/adapters/io_adapter.dart#L119

But `io_adapter` does not abort the request when `connectTimeout` and `sendTimeout` are occurs. And we use `socket.destroy()` instead of `socket.close()`.

https://api.dart.dev/stable/2.16.1/dart-io/Socket/close.html

> Close the target consumer.
>
> NOTE: Writes to the [IOSink](https://api.dart.dev/stable/2.16.1/dart-io/IOSink-class.html) may be buffered, and may not be flushed by a call to close(). To flush all buffered writes, call flush() before calling close().

https://api.dart.dev/stable/2.16.1/dart-io/Socket/destroy.html
> Destroys the socket in both directions.
> 
> Calling [destroy](https://api.dart.dev/stable/2.16.1/dart-io/Socket/destroy.html) will make the send a [close](https://api.dart.dev/stable/2.16.1/dart-io/Socket/close.html) event on the stream and will no longer react on data being piped to it.
>
> Call close (inherited from [IOSink](https://api.dart.dev/stable/2.16.1/dart-io/IOSink-class.html)) to only close the [Socket](https://api.dart.dev/stable/2.16.1/dart-io/Socket-class.html) for sending data.