### PR TITLE
Fixing multi value headers so they are serialized correctly

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -54,7 +54,7 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
 
       //Set Headers
       options.headers.forEach((k, v) {
-        if (v != null) request.headers.set(k, '$v');
+        if (v != null) request.headers.set(k, v);
       });
     } on SocketException catch (e) {
       if (e.message.contains('timed out')) {

--- a/dio/test/request_test.dart
+++ b/dio/test/request_test.dart
@@ -88,11 +88,9 @@ void main() {
 
 
     test('#test multi value headers', () async {
-      Iterable<String> multiValue = ['value1', 'value2'];
-
       Response response = await dio.get(
         '/multi-value-header',
-         options: Options(headers: {'x-multi-value-request-header': multiValue})
+         options: Options(headers: {'x-multi-value-request-header': ['value1', 'value2']})
       );
       expect(response.statusCode, 200);
       expect(response.headers.value("x-multi-value-request-header-echo"), equals('value1, value2'));

--- a/dio/test/request_test.dart
+++ b/dio/test/request_test.dart
@@ -86,6 +86,18 @@ void main() {
       assert(ri.method == 'GET');
     });
 
+
+    test('#test multi value headers', () async {
+      Iterable<String> multiValue = ['value1', 'value2'];
+
+      Response response = await dio.get(
+        '/multi-value-header',
+         options: Options(headers: {'x-multi-value-request-header': multiValue})
+      );
+      expect(response.statusCode, 200);
+      expect(response.headers.value("x-multi-value-request-header-echo"), equals('value1, value2'));
+    });
+
     test('#test request with URI', () async {
       Response response;
 

--- a/dio/test/utils.dart
+++ b/dio/test/utils.dart
@@ -74,6 +74,17 @@ Future<void> startServer() async {
         return;
       }
 
+      if (path == '/multi-value-header') {
+        response.headers.contentType = ContentType('application', 'json');
+        response.headers.add("x-multi-value-request-header-echo", request.headers.value("x-multi-value-request-header").toString());
+        response
+          ..statusCode = 200
+          ..contentLength = -1
+          ..write('');
+        response.close();
+        return;
+      }
+
       if (path == '/download') {
         const content = 'I am a text file';
         response.headers.set('content-encoding', 'plain');


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [x] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [x] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass

This merge request fixes / refers to the following issues: There was a change in version 4.0.1 that converted request header to their string values. This breaks multi value request headers as the get serialized like this `[value1,value2]` instead of like this `value1,value2`

### Pull Request Description
Change has been made to use the previous code, which worked in 4.0.0. This bug was found after upgrading from 4.0.0 to 4.0.6


